### PR TITLE
feat: fix guest graphics packaging and Wine Z: home

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,10 @@ ROOT := $(realpath $(dir $(lastword $(MAKEFILE_LIST))))
 
 # ── 配置 ──
 NATIVE_ARCH ?= x86_64
+GUEST_ARCH ?= x86_64
 BUILD_GUEST_GFX ?= 1
 export NATIVE_ARCH
+export GUEST_ARCH
 export BUILD_GUEST_GFX
 
 CONFIG    := $(NATIVE_ARCH)
@@ -32,7 +34,7 @@ endif
 # ── 关键产物 (用于验证构建是否完成) ──
 DEPS_SENTINEL   := $(BUILD_DIR)/sysroot-ext/usr/lib/x86_64-linux-ohos/libfreetype.so.6
 WINE_SENTINEL   := $(BUILD_DIR)/wine-native/tools/winegcc/winegcc
-GUEST_GFX_SENTINEL := $(BUILD_DIR)/guest_gfx/$(NATIVE_ARCH)/winehua-guest-gfx.env
+GUEST_GFX_SENTINEL := $(BUILD_DIR)/guest_gfx/$(GUEST_ARCH)/winehua-guest-gfx.env
 
 # ============================================================
 # 默认目标
@@ -202,7 +204,7 @@ assemble-$(1): $$(STAMPS)/$(1)/assemble
 $$(STAMPS)/$(1)/assemble: $(SCRIPTS)/assemble.sh $(SCRIPTS)/env.sh \
 	$$(STAMPS)/wine-$(1) $$(STAMPS)/$(1)/native | $$(STAMPS)/$(1)
 	@echo "=== assemble ($(1)) ==="
-	NATIVE_ARCH=$(1) BUILD_GUEST_GFX=$(BUILD_GUEST_GFX) bash $(SCRIPTS)/assemble.sh
+	NATIVE_ARCH=$(1) GUEST_ARCH=$(GUEST_ARCH) BUILD_GUEST_GFX=$(BUILD_GUEST_GFX) bash $(SCRIPTS)/assemble.sh
 	@touch $$@
 endef
 $(foreach a,arm64-v8a x86_64,$(eval $(call assemble_rule,$(a))))

--- a/entry/src/main/cpp/types/libentry/Index.d.ts
+++ b/entry/src/main/cpp/types/libentry/Index.d.ts
@@ -1,5 +1,5 @@
 export const startServer: (sockPath: string) => boolean;
-export const launchClient: (exePath: string, argv: string[], sockPath: string, libPath: string) => number;
+export const launchClient: (exePath: string, argv: string[], sockPath: string, libPath: string, homeDir: string) => number;
 export const stopClient: () => void;
 export const stopAll: () => void;
 export const setStateCallback: (cb: (state: string) => void) => void;
@@ -8,7 +8,7 @@ export const setPendingToplevel: (id: number) => void;
 export const getCurrentToplevelId: () => number;
 export const destroyToplevel: (id: number) => void;
 export const sendToplevelClose: (id: number) => void;
-export const runWineExe: (binDir: string, sockPath: string, libPath: string, exePath: string) => void;
+export const runWineExe: (binDir: string, sockPath: string, libPath: string, exePath: string, homeDir: string) => void;
 export const checkWinePrefix: () => boolean;
 export const resetWinePrefix: () => void;
 export const setOutputSize: (w: number, h: number) => void;

--- a/entry/src/main/cpp/wine_exe.cpp
+++ b/entry/src/main/cpp/wine_exe.cpp
@@ -1,6 +1,7 @@
 #include <napi/native_api.h>
 #include "wine_env.h"
 #include "wine_process.h"
+#include "broker.h"
 #include "graphics_broker.h"
 #include "wayland_server.h"
 
@@ -23,16 +24,23 @@
 extern napi_threadsafe_function gStateTsfn;
 
 napi_value RunWineExe(napi_env env, napi_callback_info info) {
-    size_t argc = 4;
-    napi_value args[4];
+    size_t argc = 5;
+    napi_value args[5] = {};
     napi_get_cb_info(env, info, &argc, args, nullptr, nullptr);
     if (argc < 4) return nullptr;
 
-    char binDir[512] = {}, sockPath[512] = {}, libPath[2048] = {}, wineExe[1024] = {};
+    char binDir[512] = {}, sockPath[512] = {}, libPath[2048] = {}, wineExe[1024] = {}, homePath[1024] = {};
     napi_get_value_string_utf8(env, args[0], binDir, sizeof(binDir), nullptr);
     napi_get_value_string_utf8(env, args[1], sockPath, sizeof(sockPath), nullptr);
     napi_get_value_string_utf8(env, args[2], libPath, sizeof(libPath), nullptr);
     napi_get_value_string_utf8(env, args[3], wineExe, sizeof(wineExe), nullptr);
+    if (argc >= 5) {
+        napi_get_value_string_utf8(env, args[4], homePath, sizeof(homePath), nullptr);
+    }
+
+    std::string homeDir(homePath);
+    if (homeDir.empty()) homeDir = gBrokerHomeDir;
+    if (homeDir.empty()) homeDir = "/storage/Users/currentUser/Download";
 
     std::string exePath(wineExe);
     {
@@ -44,7 +52,8 @@ napi_value RunWineExe(napi_env env, napi_callback_info info) {
         }
     }
 
-    OH_LOG_INFO(LOG_APP, "[Wine] runWineExe bin=%{public}s exe=%{public}s (final=%{public}s)", binDir, wineExe, exePath.c_str());
+    OH_LOG_INFO(LOG_APP, "[Wine] runWineExe bin=%{public}s exe=%{public}s (final=%{public}s) home=%{public}s",
+                binDir, wineExe, exePath.c_str(), homeDir.c_str());
 
     std::string sockStr(sockPath);
     auto pos = sockStr.find_last_of('/');
@@ -53,7 +62,6 @@ napi_value RunWineExe(napi_env env, napi_callback_info info) {
 
     int audioBootstrapFd = -1;
 
-    std::string homeDir = "/storage/Users/currentUser/Download";
     std::vector<std::string> envStrs = BuildWineEnv(sockDir, sockName, libPath, binDir, audioBootstrapFd, homeDir);
     std::vector<char*> envp;
     for (auto& s : envStrs) envp.push_back((char*)s.c_str());

--- a/entry/src/main/ets/pages/Index.ets
+++ b/entry/src/main/ets/pages/Index.ets
@@ -95,6 +95,7 @@ struct Index {
   @State initOverlayVisible: boolean = false;
   @State initOverlayText: string = '';
   private hasRawfileWineData: boolean = false;
+  private zHome: string = '/storage/Users/currentUser/Download';
 
   aboutToAppear(): void {
     this.hasRawfileWineData = this.detectRawfileWineData();
@@ -318,7 +319,9 @@ struct Index {
     // HOME 目录 (Z: 映射目标), 通过 DocumentViewPicker 获取 Download 路径
     const documentViewPicker = new picker.DocumentViewPicker();
     let documentSaveResult = await documentViewPicker.save({ pickerMode: picker.DocumentPickerMode.DOWNLOAD });
-    const zHome = new fileUri.FileUri(documentSaveResult[0]).path + '/';
+    const pickerHome = new fileUri.FileUri(documentSaveResult[0]).path;
+    this.zHome = pickerHome.endsWith('/') ? pickerHome : `${pickerHome}/`;
+    hilog.info(DOMAIN, 'wine', 'auto-init: Z home=%{public}s', this.zHome);
     // 检查是否需要解压 wine 数据文件
     hilog.info(DOMAIN, 'wine', 'auto-init: check marker=%{public}s', `${WINE_ROOT}/share/wine/wine.inf`);
     let needExtract = true;
@@ -335,7 +338,7 @@ struct Index {
       this.setInitStatus('启动服务失败', false);
       return;
     }
-    testNapi.launchClient(BOX64, [], SOCK, `${BIN_DIR}:${WINE_LIB}`, zHome);
+    testNapi.launchClient(BOX64, [], SOCK, `${BIN_DIR}:${WINE_LIB}`, this.zHome);
   }
 
   private doReset = (): void => {
@@ -357,7 +360,7 @@ struct Index {
   private doRun = (name: string): void => {
     this.statusText = '启动中...';
     let exePath = this.curDir + '/' + name;
-    testNapi.runWineExe(BIN_DIR, SOCK, `${WINE_BIN}:${WINE_LIB}`, exePath);
+    testNapi.runWineExe(BIN_DIR, SOCK, `${WINE_BIN}:${WINE_LIB}`, exePath, this.zHome);
   }
 
   private relPath = (): string => {

--- a/entry/src/main/ets/pages/Index.ets
+++ b/entry/src/main/ets/pages/Index.ets
@@ -322,6 +322,12 @@ struct Index {
     const pickerHome = new fileUri.FileUri(documentSaveResult[0]).path;
     this.zHome = pickerHome.endsWith('/') ? pickerHome : `${pickerHome}/`;
     hilog.info(DOMAIN, 'wine', 'auto-init: Z home=%{public}s', this.zHome);
+    const gamesDir = `${this.zHome}games`;
+    if (!ensureDirectory(gamesDir)) {
+      this.setInitStatus('创建 games 目录失败', false);
+      return;
+    }
+    hilog.info(DOMAIN, 'wine', 'auto-init: games directory=%{public}s', gamesDir);
     // 检查是否需要解压 wine 数据文件
     hilog.info(DOMAIN, 'wine', 'auto-init: check marker=%{public}s', `${WINE_ROOT}/share/wine/wine.inf`);
     let needExtract = true;

--- a/scripts/assemble.sh
+++ b/scripts/assemble.sh
@@ -11,6 +11,7 @@ assemble_pad() {
     log "=== 组装布局 ($NATIVE_ARCH) ==="
 
     local wine_data="$STAGING_DIR/wine-data"
+    local guest_arch="${GUEST_ARCH:-x86_64}"
     rm -rf "$STAGING_DIR"
     rm -rf "$wine_data"
     mkdir -p "$wine_data/bin/x86_64-windows"
@@ -264,15 +265,15 @@ HKLM,%FontSubStr%,"Courier New",,"Noto Sans Mono"' "$wine_data/share/wine/wine.i
     fi
 
     # guest GPU 库 (Mesa/VirGL, 供 GraphicsBroker 注入到 Wine LD_LIBRARY_PATH)
-    if [ -d "$BUILD_DIR/guest_gfx/$NATIVE_ARCH/lib" ]; then
+    if [ -d "$BUILD_DIR/guest_gfx/$guest_arch/lib" ]; then
         mkdir -p "$wine_data/bin/guest_gfx"
-        cp -a "$BUILD_DIR/guest_gfx/$NATIVE_ARCH/"* "$wine_data/bin/guest_gfx/"
-        log "  guest_gfx ($NATIVE_ARCH): $(ls "$wine_data/bin/guest_gfx/lib"/*.so* 2>/dev/null | wc -l) .so files"
+        cp -a "$BUILD_DIR/guest_gfx/$guest_arch/"* "$wine_data/bin/guest_gfx/"
+        log "  guest_gfx ($guest_arch): $(ls "$wine_data/bin/guest_gfx/lib"/*.so* 2>/dev/null | wc -l) .so files"
     else
         if [ "${BUILD_GUEST_GFX:-0}" = "1" ]; then
-            err "BUILD_GUEST_GFX=1 but build/guest_gfx/$NATIVE_ARCH/lib is missing"
+            err "BUILD_GUEST_GFX=1 but build/guest_gfx/$guest_arch/lib is missing"
         fi
-        log "  guest_gfx: SKIP (build/guest_gfx/$NATIVE_ARCH/lib not found)"
+        log "  guest_gfx: SKIP (build/guest_gfx/$guest_arch/lib not found)"
     fi
 
     # -- 3. 打包 zip → rawfile (不带 wine-data/ 前缀) --
@@ -296,4 +297,3 @@ log "=== 组装布局 ($NATIVE_ARCH) ==="
 
 # 统一使用 rawfile zip 布局
 assemble_pad
-

--- a/scripts/build_deps.sh
+++ b/scripts/build_deps.sh
@@ -15,7 +15,7 @@ bash "$SCRIPT_DIR/build_xkbcommon.sh"
 # XKB 键盘布局数据 (xkeyboard-config, Wine 键盘驱动依赖, 架构无关)
 bash "$SCRIPT_DIR/build_xkbconfig.sh"
 
-# Guest GPU Mesa/VirGL 库 (输出到 build/guest_gfx/) — 实验性, 默认跳过
+# Guest GPU Mesa/VirGL 库 (输出到 build/guest_gfx/$GUEST_ARCH/)
 # Wine 标准 OpenGL 路径 (opengl32 → winewayland.drv → compositor EGL) 不需要此 bundle
 # 设置 BUILD_GUEST_GFX=1 启用 (需要 thirdparty/mesa + libdrm + wayland-protocols >= 1.38)
 if [ "${BUILD_GUEST_GFX:-0}" = "1" ]; then
@@ -45,7 +45,7 @@ static inline int HiLogPrint(unsigned int d, unsigned int l, unsigned int t, con
 #endif
 #endif
 HILEOF
-    bash "$SCRIPT_DIR/build_ohos_guest_gfx.sh"
+    NATIVE_ARCH="${GUEST_ARCH:-x86_64}" bash "$SCRIPT_DIR/build_ohos_guest_gfx.sh"
 else
     log "guest_gfx: SKIP (设置 BUILD_GUEST_GFX=1 启用 Mesa/VirGL 图形测试 bundle)"
 fi


### PR DESCRIPTION
## Summary

- Separate `GUEST_ARCH=x86_64` from the HAP host `NATIVE_ARCH`, so ARM64 builds package the x86_64 Mesa/VirGL guest runtime correctly.
- Preserve the exact Download picker package directory as Wine `HOME`, including subsequent NAPI/broker launches, so the virtual Z: drive maps to the package directory.
- Create `Download/<bundle-name>/games` automatically after the picker grants access.

## Validation

- `make NATIVE_ARCH=arm64-v8a` completed successfully in the repository Docker environment.
- Signed ARM64 HAP generated successfully.
- Verified guest `libEGL.so.1` and `virtio_gpu_dri.so` are x86-64; host `libentry.so` is AArch64.
- Verified the HAP-embedded `wine-data.zip` matches the assembled source archive.
- `scripts/check-submodules.sh` reports all tracked submodules match their configured remote branches.
- Installed and launched successfully on an ARM64 tablet.