### PR TITLE
fix(runtime): harden Wayland fullscreen compatibility

### DIFF
--- a/docs/CURRENT_STATUS.md
+++ b/docs/CURRENT_STATUS.md
@@ -1,6 +1,6 @@
 # Wine for HarmonyOS — 当前状态
 
-> 更新: 2026-07-13
+> 更新: 2026-07-15
 > 状态: ✅ VirGL | ✅ Audio | ✅ Explorer 桌面 | ✅ 输入 | ✅ 多窗口
 
 ---
@@ -34,6 +34,13 @@ Host-broker 音频引擎：Wine 侧通过 IPC + ring buffer 传输 PCM，宿主�
 ### 7. VirGL / OpenGL ✅
 
 guest Mesa (virpipe Gallium driver) → Unix socket → virgl_test_server (NCP 子进程) → virglrenderer → host EGL。支持 guest Mesa WGL contexts。性能优化：Native VSync 帧同步、帧缓冲复用、subsurface 合成签名。
+
+### 8. Wayland 全屏模式模拟 ✅
+
+Wayland 不允许客户端切换宿主显示模式。WineHua 在同一无边框顶层窗口进入
+`WINE_SWP_FULLSCREEN` 时保留进入前的客户区尺寸，并让 Win32 屏幕指标继续返回该逻辑模式。
+宿主输出尺寸和零拷贝渲染路径保持不变。该机制已验证可避免低分辨率游戏在物理全屏
+切换后按错误 pitch 写入旧缓冲区。
 
 ---
 
@@ -84,6 +91,10 @@ NCP 子进程 (appspawn)
 | dnsapi / nsiproxy 编译错误 | 跳过 | mingw 交叉编译 musl 不兼容 |
 | Explorer 启动的程序 conhost 崩溃 | console 程序无法从桌面启动 | Box64 Signal 3 (SIGTRAP) |
 | WINE_MONO=never 未设置 | wineboot 初始化时 Mono 安装尝试崩溃 | mscoree.dll 触发 install_mono → DialogBoxW |
+| 低分辨率全屏绝对指针不匹配 | 全屏游戏内鼠标位置偏移 | 画面已由逻辑模式扩展到物理窗口，但 Wayland 绝对指针仍按物理窗口坐标进入 Wine；尚未建立渲染变换与输入逆变换的共享契约 |
+| 全屏宽高比适配 | 4:3 内容可能被拉伸到 16:10 | 当前优先保持游戏可运行，尚未加入等比居中和黑边区域输入裁剪 |
+| 旧 DirectDraw 颜色格式 | Rich4 等 15/16 位或调色板游戏仍可能花屏 | 需要分别验证调色板更新、RGB555/RGB565 传输和光标 surface 格式，不能用全局色彩交换修复 |
+| 全屏模式模拟覆盖范围 | 不经过同一窗口“小客户区 → 全屏”转换的程序不会触发 | 后续应从 Wine 显式显示模式状态统一驱动，而不是扩展更多窗口特征判断 |
 
 ---
 

--- a/entry/src/main/cpp/graphics_broker.cpp
+++ b/entry/src/main/cpp/graphics_broker.cpp
@@ -715,6 +715,7 @@ void GraphicsBroker::AppendWineEnv(std::vector<std::string>& env) const
     env.push_back(std::string("WINEHUA_FRAME_ZERO_COPY=") + (state.zeroCopyFramePath ? "1" : "0"));
     env.push_back("WINEHUA_FRAME_TRANSPORT=" + state.frameTransportMode);
     env.push_back(std::string("WINEHUA_GUEST_GFX_READY=") + (state.guestReceiverPresent ? "1" : "0"));
+    env.push_back("WINEHUA_FULLSCREEN_MODE_EMULATION=1");
     env.push_back("WINEHUA_GUEST_GFX_MODE=" + (state.guestReceiverMode.empty() ? std::string("stock-egl")
                                                                                 : state.guestReceiverMode));
     if (!state.guestReceiverRuntimeDir.empty()) env.push_back("WINEHUA_GUEST_GFX_DIR=" + state.guestReceiverRuntimeDir);

--- a/entry/src/main/cpp/wayland_server.cpp
+++ b/entry/src/main/cpp/wayland_server.cpp
@@ -224,7 +224,8 @@ void WaylandServer::compositor_create_surface(wl_client* client, wl_resource* co
                 self->toplevelSurfaceMap_.erase(sd->toplevelId);
             }
             InputManager::GetInstance()->OnSurfaceDestroyed(r);
-            self->FireToplevelEvent(sd->toplevelId, "destroyed");
+            if (self->OnToplevelDestroyed(sd->toplevelId))
+                self->FireToplevelEvent(sd->toplevelId, "destroyed");
         }
         delete sd;
     });
@@ -399,17 +400,12 @@ void WaylandServer::surface_destroy(wl_client*, wl_resource* r) {
             self->toplevelSurfaceMap_.erase(sd->toplevelId);
         }
         // 清理 toplevel 像素数据 + 标记 root dirty
-        self->OnToplevelDestroyed(sd->toplevelId);
+        const bool firstDestroy = self->OnToplevelDestroyed(sd->toplevelId);
         // 重置 InputManager 焦点: 防止后续 Inject*Leave 引用已销毁的 surface
         // (否则 Wine 收到 invalid object 协议错误 → 断开连接)
         InputManager::GetInstance()->OnSurfaceDestroyed(r);
-        // 如果是 desktop root 被销毁，重置 root ID，等待下一个 explorer toplevel
-        if (sd->toplevelId == self->GetDesktopRootToplevelId()) {
-            OH_LOG_INFO(LOG_APP, "[MW] desktop root toplevel #%{public}u destroyed, clearing root",
-                        sd->toplevelId);
-            self->SetDesktopRootToplevelId(0);
-        }
-        self->FireToplevelEvent(sd->toplevelId, "destroyed");
+        if (firstDestroy)
+            self->FireToplevelEvent(sd->toplevelId, "destroyed");
     }
     // subsurface 销毁: 清除 layer + 标记 root dirty 触发重绘 (移除残留像素)
     if (sd && sd->isSubsurface) {
@@ -522,6 +518,31 @@ void WaylandServer::surface_commit(wl_client*, wl_resource* surfRes) {
             }
             OH_LOG_INFO(LOG_APP, "[MW-GEO] using window_geometry: src=%{public}dx%{public}d geo=(%{public}d,%{public}d %{public}dx%{public}d) screen=(%{public}d,%{public}d)",
                         w, h, contentOffX, contentOffY, contentW, contentH, screenX, screenY);
+        }
+
+        const int requestedOffX = contentOffX;
+        const int requestedOffY = contentOffY;
+        const int requestedContentW = contentW;
+        const int requestedContentH = contentH;
+        contentOffX = std::clamp(contentOffX, 0, w);
+        contentOffY = std::clamp(contentOffY, 0, h);
+        contentW = std::clamp(contentW, 0, w - contentOffX);
+        contentH = std::clamp(contentH, 0, h - contentOffY);
+        if (contentW <= 0 || contentH <= 0) {
+            contentOffX = 0;
+            contentOffY = 0;
+            contentW = w;
+            contentH = h;
+        }
+        if (contentOffX != requestedOffX || contentOffY != requestedOffY ||
+            contentW != requestedContentW || contentH != requestedContentH) {
+            OH_LOG_WARN(LOG_APP,
+                        "[MW-BUFFER] geometry clamped buffer=%{public}dx%{public}d "
+                        "requested=(%{public}d,%{public}d %{public}dx%{public}d) "
+                        "safe=(%{public}d,%{public}d %{public}dx%{public}d)",
+                        w, h, requestedOffX, requestedOffY,
+                        requestedContentW, requestedContentH,
+                        contentOffX, contentOffY, contentW, contentH);
         }
 
         // 复制像素时 strip stride padding, 只提取 content 区域
@@ -1354,8 +1375,9 @@ void WaylandServer::UnregisterToplevelResource(uint32_t toplevelId) {
     }
 }
 
-void WaylandServer::OnToplevelDestroyed(uint32_t toplevelId) {
+bool WaylandServer::OnToplevelDestroyed(uint32_t toplevelId) {
     std::lock_guard<std::mutex> lk(toplevelMutex_);
+    if (!destroyedToplevels_.insert(toplevelId).second) return false;
     toplevelPixels_.erase(toplevelId);
     toplevelW_.erase(toplevelId);
     toplevelH_.erase(toplevelId);
@@ -1376,6 +1398,14 @@ void WaylandServer::OnToplevelDestroyed(uint32_t toplevelId) {
     if (IsDesktopMode() && toplevelId != desktopRootToplevelId_) {
         if (desktopRootToplevelId_ > 0) toplevelDirty_[desktopRootToplevelId_] = true;
     }
+    if (toplevelId == desktopRootToplevelId_) {
+        OH_LOG_INFO(LOG_APP,
+                    "[MW] desktop root toplevel #%{public}u destroyed, clearing root",
+                    toplevelId);
+        desktopRootToplevelId_ = 0;
+    }
+    desktopCompositionSignature_ = 0;
+    return true;
 }
 
 void WaylandServer::SendToplevelClose(uint32_t toplevelId) {

--- a/entry/src/main/cpp/wayland_server.h
+++ b/entry/src/main/cpp/wayland_server.h
@@ -63,7 +63,7 @@ public:
     void RegisterToplevelResource(uint32_t toplevelId, wl_resource* tl);
     void UnregisterToplevelResource(uint32_t toplevelId);
     // 清理 toplevel 像素数据 + 标记 root dirty (desktop mode)
-    void OnToplevelDestroyed(uint32_t toplevelId);
+    bool OnToplevelDestroyed(uint32_t toplevelId);
     void SendToplevelClose(uint32_t toplevelId);
     // 统一状态转换 (确保 minimize/maximize/restore 涉及的 map 操作原子化)
     void SetToplevelMinimized(uint32_t id);
@@ -197,6 +197,7 @@ private:
     std::atomic<uint32_t> nextToplevelId_{1};
     std::unordered_map<uint32_t, wl_resource*> toplevelResources_;
     std::mutex toplevelResMutex_;
+    std::unordered_set<uint32_t> destroyedToplevels_;
 
     // toplevelId -> wl_surface 映射 (input focus 查找)
     std::unordered_map<uint32_t, wl_resource*> toplevelSurfaceMap_;

--- a/entry/src/main/cpp/xdg_shell.cpp
+++ b/entry/src/main/cpp/xdg_shell.cpp
@@ -95,7 +95,11 @@ static void tl_set_max_size(wl_client* client, wl_resource* tlRes, int32_t w, in
     // Wine 最大化时不调 set_maximized, 只设 max_size → 主动发 configure
     auto* ws = WaylandServer::GetInstance();
     int32_t workH = ws->GetWorkAreaHeight();
+    const bool workAreaFitsMinimum =
+        (sd->minWidth <= 0 || w >= sd->minWidth) &&
+        (sd->minHeight <= 0 || workH >= sd->minHeight);
     if (!sd->maximized && w >= ws->outputW_ && h >= workH &&
+        workAreaFitsMinimum &&
         sd->toplevelId != ws->GetDesktopRootToplevelId()) {
         sd->preMaxW = ws->GetToplevelW(sd->toplevelId);
         sd->preMaxH = ws->GetToplevelH(sd->toplevelId);
@@ -113,6 +117,10 @@ static void tl_set_max_size(wl_client* client, wl_resource* tlRes, int32_t w, in
         xdg_surface_send_configure(xdg->xdgSurface, wl_display_next_serial(dpy));
         OH_LOG_INFO(LOG_APP, "[XDG] max_size→maximize tl=%{public}u → configure(%{public}d,%{public}d)",
                     sd->toplevelId, w, workH);
+    } else if (!workAreaFitsMinimum && w >= ws->outputW_ && h >= workH) {
+        OH_LOG_INFO(LOG_APP,
+                    "[XDG] skip auto-maximize tl=%{public}u: work=%{public}dx%{public}d min=%{public}dx%{public}d",
+                    sd->toplevelId, w, workH, sd->minWidth, sd->minHeight);
     } else {
         OH_LOG_INFO(LOG_APP, "[XDG] tl_set_max_size toplevel=%{public}u %{public}dx%{public}d",
                     sd->toplevelId, w, h);
@@ -216,13 +224,12 @@ static void xs_destroy(wl_client*, wl_resource* r) {
     auto* d = static_cast<XdgSurface*>(wl_resource_get_user_data(r));
     OH_LOG_INFO(LOG_APP, "[MW-Life] xs_destroy xdg=%{public}p wlSurf=%{public}p",
                 r, d ? d->wlSurface : nullptr);
-    if (d && d->wlSurface) {
-        auto* sd = static_cast<SurfaceData*>(wl_resource_get_user_data(d->wlSurface));
-        if (sd && sd->hasToplevel) {
-            OH_LOG_INFO(LOG_APP, "[MW-Life] xs_destroy → OnToplevelDestroyed tl=%{public}u", sd->toplevelId);
-            WaylandServer::GetInstance()->OnToplevelDestroyed(sd->toplevelId);
-            WaylandServer::GetInstance()->FireToplevelEvent(sd->toplevelId, "destroyed");
-        }
+    if (d && d->toplevelId) {
+        OH_LOG_INFO(LOG_APP, "[MW-Life] xs_destroy -> OnToplevelDestroyed tl=%{public}u",
+                    d->toplevelId);
+        auto* ws = WaylandServer::GetInstance();
+        if (ws->OnToplevelDestroyed(d->toplevelId))
+            ws->FireToplevelEvent(d->toplevelId, "destroyed");
     }
     wl_resource_destroy(r);
 }
@@ -295,15 +302,15 @@ static void xs_resource_destroy(wl_resource* r) {
     // 必须在此处也做 compositor 清理 (等价于 xs_destroy 的逻辑),
     // 否则已断开进程的窗口像素永久滞留。
     auto* d = static_cast<XdgSurface*>(wl_resource_get_user_data(r));
-    if (d && d->wlSurface) {
-        auto* sd = static_cast<SurfaceData*>(wl_resource_get_user_data(d->wlSurface));
-        if (sd && sd->hasToplevel) {
-            OH_LOG_INFO(LOG_APP, "[MW-Life] xs_resource_destroy → OnToplevelDestroyed tl=%{public}u (client disconnect)", sd->toplevelId);
-            WaylandServer::GetInstance()->OnToplevelDestroyed(sd->toplevelId);
-            WaylandServer::GetInstance()->FireToplevelEvent(sd->toplevelId, "destroyed");
-        }
+    if (d && d->toplevelId) {
+        OH_LOG_INFO(LOG_APP,
+                    "[MW-Life] xs_resource_destroy -> OnToplevelDestroyed tl=%{public}u (client disconnect)",
+                    d->toplevelId);
+        auto* ws = WaylandServer::GetInstance();
+        if (ws->OnToplevelDestroyed(d->toplevelId))
+            ws->FireToplevelEvent(d->toplevelId, "destroyed");
     }
-    delete static_cast<XdgSurface*>(wl_resource_get_user_data(r));
+    delete d;
 }
 
 // -- xdg_wm_base 实现 --

--- a/entry/src/main/ets/service/WineWindowManager.ets
+++ b/entry/src/main/ets/service/WineWindowManager.ets
@@ -104,12 +104,16 @@ export class WineWindowManager {
         d.width, d.height, this.displayScale.toFixed(2), this.scaleBoost.toFixed(2));
       testNapi.setDisplayScale(this.displayScale * this.scaleBoost);
 
-      // Wine 输出尺寸: 沉浸模式下 avoid area 为 0, 直接用显示尺寸
+      // Tablet desktop is landscape. The display API can briefly report the
+      // pre-rotation portrait size while the Ability is starting.
       const s = this.displayScale * this.scaleBoost;
-      const outW = Math.round(d.width / s);
-      const outH = Math.round(d.height / s);
-      hilog.info(DOMAIN, TAG, '[MW] display %{public}dx%{public}d → output %{public}dx%{public}d',
-        d.width, d.height, outW, outH);
+      const displayW = this.isDesktopMode ? Math.max(d.width, d.height) : d.width;
+      const displayH = this.isDesktopMode ? Math.min(d.width, d.height) : d.height;
+      const outW = Math.round(displayW / s);
+      const outH = Math.round(displayH / s);
+      hilog.info(DOMAIN, TAG,
+        '[MW] display raw=%{public}dx%{public}d normalized=%{public}dx%{public}d → output %{public}dx%{public}d',
+        d.width, d.height, displayW, displayH, outW, outH);
       testNapi.setOutputSize(outW, outH);
     } catch (_) {
       this.displayScale = 1.61;


### PR DESCRIPTION
## Summary

- Emulate legacy fullscreen display modes in Wine when the same visible borderless popup enters `WINE_SWP_FULLSCREEN`.
- Treat opaque GL CPU-readback buffers as XRGB instead of ARGB.
- Harden Wayland startup sizing, SHM geometry validation, maximize negotiation, and idempotent toplevel teardown.
- Keep the VirGL SurfaceQueue external-OES zero-copy path unchanged.

## Root cause

Pal2 creates and initially commits a 640x480 surface, then its borderless top-level is expanded to the 1280x800 host output. Wayland cannot switch the physical output to the legacy game mode. Returning 1280 through Win32 screen metrics made Pal2 calculate a 0xA00 RGB565 pitch while its Bink target allocation remained 640x480, resulting in an out-of-bounds write in `binkw32.dll`.

The Wine change preserves the pre-fullscreen client size as process-local screen metrics only for that explicit same-window fullscreen transition, and clears the emulation on fullscreen exit or window destruction. It contains no game whitelist or resolution threshold.

## Validation

- Rebased on upstream master `78d2610`.
- `make NATIVE_ARCH=arm64-v8a` completed successfully in the isolated WSL ext4 Docker environment after the final rebase.
- Physical ARM64 HarmonyOS Pad: Pal2 displays normally and no longer crashes in `binkw32.dll`; VirGL SurfaceQueue zero-copy remains active.
- Signed HAP SHA-256: `8ec0a2d6d80a86633943cec4ad00d601352c1ab4fe41591ad24b401b463a7e2b`.
- Embedded/staging `wine-data.zip` SHA-256: `2da04507ecee0521cc24de4785607405da43bb95080f8ead906fc14e042bf57e`.
- Guest EGL is x86-64 and host `libentry.so` is ARM aarch64.

## Known limitations

- Absolute pointer coordinates are still based on the physical fullscreen window, so low-resolution fullscreen mouse/touch mapping is offset.
- 4:3 content may stretch to a 16:10 output; aspect-preserving letterboxing and its inverse input transform are not included.
- Rich4 and similar palette or RGB555/RGB565 DirectDraw paths may still show incorrect colors or cursors.
- Mode emulation currently requires the same visible borderless popup to transition from its logical client size into Wine fullscreen.

## Wine submodule

Branch: `winehua/wine:feature/runtime-compatibility`

- `7614786ffd8` `fix(win32u): emulate fullscreen display modes on Wayland`
- `6c77f63b632` `fix(winewayland): treat GL readback buffers as opaque XRGB`

Per the submodule workflow, merge the Wine feature branch into its default branch before finalizing the main-repository gitlink.