### PR TITLE
feat: 支持通过 Docker 卷导入 DevEco 构建配置文件及签名。

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,8 +32,12 @@ RUN ln -sf /usr/lib/x86_64-linux-gnu/libxml2.so.16 /usr/lib/x86_64-linux-gnu/lib
 WORKDIR /data/src/winehua
 
 # 使用时挂载:
-#   -v /path/to/wineohos:/data/src/winehua          (项目源码)
-#   -v /path/to/harmony-sdk:/apps/harmony             (OHOS SDK)
+#   -v /path/to/wineohos:/data/src/winehua                  (项目源码)
+#   -v /path/to/harmony-sdk:/apps/harmony                   (OHOS SDK)
+# 可选: 从 Windows/DevEco Studio 直接导入签名, 免去复制到 WSL
+#   -v /mnt/c/path/to/deveco_project:/mnt/user-profile      (含 build-profile.json5 的工程目录)
+#   -v /mnt/c/path/to/signature_dir:/mnt/user-signature     (含 .cer / .p7b / .p12 的目录)
+# 两者需同时挂载才生效; 缺失任一则回退到项目内置 build-profile.json5.
 #
 # 构建:
 #   docker run --rm -v $(pwd):/data/src/winehua -v ~/huawei/command-line-tools:/apps/harmony \

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -5,6 +5,61 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/env.sh"
 
 # ============================================================
+# 工具函数: 从用户挂载目录导入 build-profile.json5 + 签名材料
+# 挂载约定 (二者需同时存在, 否则回退到项目自带模板):
+#   -v C:\path\to\winehua_project:/mnt/user-profile
+#   -v C:\path\to\signature_dir:/mnt/user-signature
+# ============================================================
+USER_PROFILE_DIR="${USER_PROFILE_DIR:-/mnt/user-profile}"
+USER_SIGNATURE_DIR="${USER_SIGNATURE_DIR:-/mnt/user-signature}"
+
+import_user_profile() {
+    local src_profile="$USER_PROFILE_DIR/build-profile.json5"
+    local dst_profile="$WINEHUA/build-profile.json5"
+
+    if [ ! -f "$src_profile" ] || [ ! -d "$USER_SIGNATURE_DIR" ]; then
+        log "未检测到用户挂载 (profile=$src_profile, signature=$USER_SIGNATURE_DIR)"
+        log "  → 使用项目内置 build-profile.json5"
+        return 0
+    fi
+
+    log "=== 检测到用户挂载, 导入 build-profile.json5 + 签名材料 ==="
+    log "  profile   : $src_profile"
+    log "  signature : $USER_SIGNATURE_DIR"
+
+    cp "$src_profile" "$dst_profile"
+
+    python3 - "$dst_profile" "$USER_SIGNATURE_DIR" <<'PY'
+import re, sys
+
+profile_path, sig_dir = sys.argv[1:]
+sig_dir = sig_dir.rstrip("/")
+
+with open(profile_path, "r", encoding="utf-8") as f:
+    content = f.read()
+
+# 仅重写签名材料三件套的路径, 其他字段 (buildOption 之类) 一律不碰
+pattern = re.compile(r'("(?:certpath|profile|storeFile)"\s*:\s*)"([^"]+)"')
+
+def rewrite(m):
+    prefix, value = m.group(1), m.group(2)
+    # 按正/反斜杠切分, 过滤空段, 取最后一段作为文件名
+    parts = [p for p in re.split(r'[\\/]+', value) if p]
+    fname = parts[-1] if parts else value
+    new_path = f"{sig_dir}/{fname}"
+    print(f"  rewrite: {value}  ->  {new_path}", file=sys.stderr)
+    return f'{prefix}"{new_path}"'
+
+content = pattern.sub(rewrite, content)
+
+with open(profile_path, "w", encoding="utf-8") as f:
+    f.write(content)
+PY
+
+    log "build-profile.json5 导入完成"
+}
+
+# ============================================================
 # 工具函数: 同步根 build-profile 的 SDK 版本
 set_sdk_versions() {
     local profile="$WINEHUA/build-profile.json5"
@@ -78,6 +133,7 @@ package_hap() {
     local unsigned_hap="$WINEHUA/entry/build/default/outputs/default/entry-default-unsigned.hap"
     local signed_hap="$WINEHUA/entry/build/default/outputs/default/entry-default-signed.hap"
 
+    import_user_profile     # <-- 优先使用用户挂载的 profile + 签名
     set_sdk_versions
     set_abi_filters
 


### PR DESCRIPTION
## 概述
本 PR 为使用 **WSL 编译**的用户提供便利: 让他们可以直接复用在 Windows 侧
通过 DevEco Studio 生成的 `build-profile.json5` 与签名材料, 免去手动
复制到 WSL 的麻烦.

### 背景 & 使用场景
DevEco Studio 目前只有 Windows / macOS 版本, 而本项目的构建流程跑在
Linux (WSL / Docker) 里. 一个常见的工作流是:

1. 在 Windows 上也克隆一份本仓库, 用 DevEco Studio 打开;
2. 通过 DevEco Studio 的 **Project Structure → Signing Configs** 一键
   生成调试/发布签名 (`.cer` / `.p7b` / `.p12` 会写入
   `C:\Users\<用户名>\.ohos\config\`, 同时 `build-profile.json5` 里
   的 `signingConfigs` 段会被自动填好, 包括加密后的密码);
3. 回到 WSL 里用本项目的 Docker 镜像做真正的交叉编译.

以往第 3 步之前, 用户需要手动把 `build-profile.json5` 和签名文件复制
进 WSL, 还得把里面的 `C:\...` 路径改成 Linux 路径. 本 PR 让这一步
彻底自动化.

## 挂载约定
新增两个可选的 bind-mount 挂载点:

| 挂载点 | 含义 | 典型来源 |
|---|---|---|
| `/mnt/user-profile` | 存放 `build-profile.json5` 的目录 | `/mnt/<盘符>/<项目目录>`, 也就是 Windows 侧克隆的仓库根目录, 例如 `/mnt/d/code/winehua` |
| `/mnt/user-signature` | 存放 `.cer` / `.p7b` / `.p12` 的目录 | 一般是 `/mnt/c/Users/<用户名>/.ohos/config`, 即 DevEco Studio 默认写签名的位置 |

两者同时挂载时, `package.sh` 会:

1. 把 `/mnt/user-profile/build-profile.json5` 复制到容器内项目根;
2. 将 `certpath` / `profile` / `storeFile` 三个字段的路径按 `\` 或 `/`
   切分, 取最后一段作为文件名, 重写为 `/mnt/user-signature/<文件名>`;
3. 其他字段 (SDK 版本、加密后的密码、`signAlg`、`buildOption` 等)
   原样保留.

任一挂载缺失则完全回退到仓库内置模板, 不影响 CI 及已有工作流.

## 使用示例
```bash
docker run --rm \
  -v $(pwd):/data/src/winehua \
  -v ~/huawei/command-line-tools:/apps/harmony \
  -v /mnt/d/code/winehua:/mnt/user-profile \
  -v /mnt/c/Users/me/.ohos/config:/mnt/user-signature \
  make NATIVE_ARCH=arm64-v8a DEVICE_TYPE=pad