### PR TITLE
ci: add GitHub Actions workflow for unsigned HAP builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,282 @@
+# .github/workflows/build.yml
+name: Build HAP (arm64-v8a, unsigned)
+
+on:
+  push:
+    branches: [master]
+    tags:
+      - 'v*'                    # v0.1.0, v1.2.3-rc1 等, 推 tag 会额外触发 release job
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
+      - '.gitignore'
+      - 'LICENSE*'
+  pull_request:
+    branches: [master]
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: 'Release tag (留空则只构建不发布)'
+        required: false
+        type: string
+
+# GITHUB_TOKEN 权限:
+#   contents: write — 拉源码 + 发布 Release (需要 write)
+#   packages: read  — 拉 GHCR 私有 buildenv 镜像
+permissions:
+  contents: write
+  packages: read
+
+jobs:
+  build:
+    name: make NATIVE_ARCH=arm64-v8a hap
+    runs-on: ubuntu-26.04
+    timeout-minutes: 180
+
+    # 容器里默认 shell 是 sh, 不认 `set -o pipefail` 等 bash 语法
+    # 这里强制所有 run step 用 bash
+    defaults:
+      run:
+        shell: bash
+
+    container:
+      image: ghcr.io/panedioic/winehua-buildenv:test
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      # ---- 让私有 submodule 走 HTTPS + GITHUB_TOKEN ----
+      # 前提: wine/box64/mesa-ohos 三个私有 submodule 与本仓库在同一账号/组织下
+      # 若跨组织, 需替换成有跨仓库权限的 PAT (存到 secrets.SUBMODULE_PAT)
+      - name: Configure git for private submodules
+        run: |
+          git config --global --add safe.directory '*'
+          git config --global \
+            url."https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/".insteadOf \
+            "git@github.com:"
+          git config --global --add \
+            url."https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/".insteadOf \
+            "https://github.com/"
+
+      - name: Checkout with submodules
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 1
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      # ---- 绕过签名: 用 stub 替换 sign.py ----
+      # scripts/package.sh 最后会调 `python3 sign.py <unsigned> <signed>`,
+      # 无签名场景下这里直接把 unsigned 拷成 "signed" 文件, 让 make hap 完整跑完
+      - name: Stub sign.py (unsigned build)
+        run: |
+          cat > sign.py <<'PY'
+          #!/usr/bin/env python3
+          # CI-only stub: 无签名构建, 直接把 unsigned HAP 拷贝为 "signed" 输出
+          import shutil, sys, os
+          src, dst = sys.argv[1], sys.argv[2]
+          os.makedirs(os.path.dirname(dst), exist_ok=True)
+          shutil.copy(src, dst)
+          print(f"[sign-stub] copied {src} -> {dst} (UNSIGNED)")
+          PY
+          chmod +x sign.py
+
+      # ---- CI-only: 无签名的 build-profile.json5 ----
+      # 从 example 派生会踩坑: example 里的 signingConfigs 指向占位符路径,
+      # hvigor 的 SignHap 任务会校验这些文件存在, 直接失败.
+      # 这里显式写一份 signingConfigs 为空的 profile, 让 hvigor 跳过 SignHap,
+      # 直接输出 entry-default-unsigned.hap.
+      - name: Provision unsigned build-profile.json5
+        run: |
+          cat > build-profile.json5 <<'JSON5'
+          {
+            "app": {
+              "signingConfigs": [],
+              "products": [
+                {
+                  "name": "default",
+                  "targetSdkVersion": "6.1.0(23)",
+                  "compatibleSdkVersion": "6.1.0(23)",
+                  "runtimeOS": "HarmonyOS",
+                  "buildOption": {
+                    "nativeCompiler": "BiSheng",
+                    "strictMode": {
+                      "caseSensitiveCheck": true,
+                      "useNormalizedOHMUrl": true
+                    }
+                  }
+                }
+              ],
+              "buildModeSet": [
+                {
+                  "name": "debug"
+                },
+                {
+                  "name": "release"
+                }
+              ]
+            },
+            "modules": [
+              {
+                "name": "entry",
+                "srcPath": "./entry",
+                "targets": [
+                  {
+                    "name": "default",
+                    "applyToProducts": ["default"]
+                  }
+                ]
+              }
+            ]
+          }
+          JSON5
+          echo "[ci] wrote unsigned build-profile.json5 (signingConfigs empty)"
+
+      # ---- 兜底: 确保 libtool m4 宏 (ltdl.m4) 存在 ----
+      # buildenv 镜像里 apt Recommends 被禁, 未显式列出的 libltdl-dev 不装.
+      # 待 Dockerfile 修好后可以删除这一步.
+      - name: Ensure libtool m4 macros present
+        run: |
+          if [ ! -f /usr/share/aclocal/ltdl.m4 ]; then
+            echo "ltdl.m4 missing, installing libltdl-dev..."
+            apt-get update
+            apt-get install -y libltdl-dev
+          else
+            echo "ltdl.m4 present, no action needed"
+          fi
+
+      - name: Show environment
+        run: |
+          echo "== toolchain =="
+          gcc --version | head -1
+          cmake --version | head -1
+          meson --version
+          ninja --version
+          python3 --version
+          java -version 2>&1 | head -1
+          echo "== OHOS SDK =="
+          ls /apps/harmony/sdk/default/openharmony/native/llvm/bin/clang
+          /apps/harmony/bin/hvigorw --version || true
+          echo "== nproc =="
+          nproc
+
+      - name: Build HAP
+        env:
+          NATIVE_ARCH: arm64-v8a
+          BUILD_GUEST_GFX: '0'
+          BUILD_WINE_MONO: '0'
+        run: |
+          set -euxo pipefail
+          make NATIVE_ARCH=arm64-v8a hap
+
+      - name: Locate artifacts
+        id: art
+        run: |
+          set -eux
+          out_dir=entry/build/default/outputs/default
+          ls -lh "$out_dir"
+          if [ -f "$out_dir/entry-default-unsigned.hap" ]; then
+            echo "hap=$out_dir/entry-default-unsigned.hap" >> "$GITHUB_OUTPUT"
+          else
+            echo "hap=$out_dir/entry-default-signed.hap" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Upload HAP
+        uses: actions/upload-artifact@v4
+        with:
+          name: WineHua-arm64-v8a-unsigned-${{ github.sha }}
+          path: ${{ steps.art.outputs.hap }}
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Upload build logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-logs-${{ github.sha }}
+          path: |
+            build/**/meson-logs/**
+            build/**/CMakeFiles/CMakeOutput.log
+            build/**/CMakeFiles/CMakeError.log
+            build/**/config.log
+          if-no-files-found: ignore
+          retention-days: 7
+
+  # ============================================================
+  # Release job: 仅在推 tag 或手动指定 release_tag 时运行
+  # ============================================================
+  release:
+    name: Publish GitHub Release
+    needs: build
+    runs-on: ubuntu-26.04
+    if: startsWith(github.ref, 'refs/tags/v') || github.event.inputs.release_tag != ''
+
+    steps:
+      - name: Checkout (for changelog)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0        # 需要历史 commit 生成 changelog
+
+      - name: Determine release tag
+        id: tag
+        run: |
+          if [ -n "${{ github.event.inputs.release_tag }}" ]; then
+            tag="${{ github.event.inputs.release_tag }}"
+          else
+            tag="${GITHUB_REF#refs/tags/}"
+          fi
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "Resolved release tag: $tag"
+
+      - name: Download HAP artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: WineHua-arm64-v8a-unsigned-${{ github.sha }}
+          path: ./release-assets
+
+      - name: Rename artifact with version
+        run: |
+          set -eux
+          cd release-assets
+          for f in *.hap; do
+            mv "$f" "WineHua-${{ steps.tag.outputs.tag }}-arm64-v8a-unsigned.hap"
+          done
+          ls -lh
+
+      - name: Generate changelog
+        run: |
+          # 找到上一个 tag (若存在)
+          prev_tag=$(git describe --tags --abbrev=0 "${{ steps.tag.outputs.tag }}^" 2>/dev/null || echo "")
+          if [ -n "$prev_tag" ]; then
+            {
+              echo "## Changes since \`$prev_tag\`"
+              echo
+              git log --pretty=format:'- %s (%h)' "$prev_tag..${{ steps.tag.outputs.tag }}"
+            } > changelog.md
+          else
+            echo "## Initial release" > changelog.md
+          fi
+          {
+            echo
+            echo
+            echo "---"
+            echo
+            echo "**Note**: This build is **unsigned**. To install on a HarmonyOS device you'll need developer mode enabled, or sign the HAP with your own certificate first."
+            echo
+            echo "Built from commit \`${GITHUB_SHA:0:7}\`."
+          } >> changelog.md
+          echo "---- changelog.md ----"
+          cat changelog.md
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.tag.outputs.tag }}
+          name: WineHua ${{ steps.tag.outputs.tag }}
+          body_path: changelog.md
+          files: release-assets/*.hap
+          draft: false
+          # -rc / -beta / -alpha 后缀自动标记为 pre-release
+          prerelease: ${{ contains(steps.tag.outputs.tag, '-rc') || contains(steps.tag.outputs.tag, '-beta') || contains(steps.tag.outputs.tag, '-alpha') }}
+          fail_on_unmatched_files: true

--- a/ci/Dockerfile.buildenv
+++ b/ci/Dockerfile.buildenv
@@ -1,0 +1,83 @@
+# ci/Dockerfile.buildenv
+#
+# 用途: WineHua CI 构建环境镜像
+#
+# 用法 (本地一次性构建, 需先把 HarmonyOS SDK 放到 ./harmony-sdk/):
+#   docker build -f ci/Dockerfile.buildenv \
+#       --build-arg SDK_SRC=./harmony-sdk \
+#       -t ghcr.io/panedioic/winehua-buildenv:test .
+#   docker push ghcr.io/panedioic/winehua-buildenv:test
+#
+# 目录约定 (与 scripts/env.sh 默认值一致):
+#   /apps/harmony/                          # TOOL_HOME
+#   /apps/harmony/sdk/default/openharmony/  # OHOS_SDK
+#   /apps/harmony/bin/hvigorw
+#   /apps/harmony/tool/node/bin/
+FROM ubuntu:26.04
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    TZ=Asia/Shanghai \
+    LANG=C.UTF-8 \
+    LC_ALL=C.UTF-8
+
+# ---- 系统依赖 (严格对齐本地开发 Dockerfile) ----
+# 注意: libltdl-dev 必须显式列出.
+# 它本是 libtool 的 Recommends 依赖, 但 Ubuntu 官方 docker base image 默认
+# 关闭 Recommends 安装, 所以不显式声明就不会被拉入, 导致 aclocal 找不到
+# ltdl.m4 里的 LT_SYS_SYMBOL_USCORE 宏, 让 libffi autogen.sh 失败.
+RUN apt-get update && apt-get install -y \
+        build-essential cmake ninja-build meson \
+        bison flex autoconf automake libtool libltdl-dev \
+        pkgconf zip git file python3 python3-pip \
+        libexpat1-dev libxml2-dev libffi-dev \
+        libfreetype-dev \
+        gcc-mingw-w64-i686 g++-mingw-w64-i686 \
+        gcc-mingw-w64-x86-64 g++-mingw-w64-x86-64 \
+        default-jdk \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# ---- Python 依赖 ----
+RUN pip3 install --break-system-packages --no-cache-dir \
+        pyyaml mako markupsafe
+
+# ---- libxml2.so.2 兼容性 (OHOS SDK 的 ld.lld 需要) ----
+# Ubuntu 26.04 提供 libxml2.so.16, 但 OHOS SDK 里的 ld.lld 依赖 libxml2.so.2
+RUN set -eux; \
+    if [ ! -e /usr/lib/x86_64-linux-gnu/libxml2.so.2 ]; then \
+        newlib="$(ls /usr/lib/x86_64-linux-gnu/libxml2.so.* 2>/dev/null | head -1)"; \
+        [ -n "$newlib" ] && ln -sf "$newlib" /usr/lib/x86_64-linux-gnu/libxml2.so.2; \
+    fi; \
+    ldconfig
+
+# ---- HarmonyOS SDK ----
+# 把本地准备好的 SDK 目录 COPY 进镜像
+# SDK_SRC 是相对于 build context 的路径, 里面需要包含:
+#   sdk/default/openharmony/
+#   bin/hvigorw
+#   tool/node/bin/node
+ARG SDK_SRC=./harmony-sdk
+COPY ${SDK_SRC} /apps/harmony
+RUN chmod -R a+rx /apps/harmony/bin \
+                  /apps/harmony/tool/node/bin \
+                  /apps/harmony/sdk/default/openharmony/native/llvm/bin \
+        2>/dev/null || true
+
+ENV TOOL_HOME=/apps/harmony \
+    OHOS_SDK=/apps/harmony/sdk/default/openharmony \
+    PATH=/apps/harmony/bin:/apps/harmony/tool/node/bin:/usr/local/bin:/usr/bin:/bin
+
+# ---- 可选: 预热 hvigorw npm 依赖 (加速首次 CI) ----
+# 失败不影响镜像可用性
+RUN /apps/harmony/bin/hvigorw --version >/dev/null 2>&1 || true
+
+# ---- 验证关键工具/文件都在 ----
+# 增加 ltdl.m4 断言, 防止未来 apt/依赖变动再次让它悄悄消失
+RUN set -eux; \
+    which gcc make cmake ninja meson bison flex autoconf pkg-config git python3 java; \
+    test -f /apps/harmony/sdk/default/openharmony/native/llvm/bin/clang; \
+    test -f /apps/harmony/bin/hvigorw; \
+    test -f /usr/share/aclocal/ltdl.m4; \
+    python3 -c 'import yaml, mako, markupsafe'
+
+WORKDIR /workspace
+CMD ["/bin/bash"]


### PR DESCRIPTION
## 概述

给项目加一套 GitHub Actions CI, 每次 push 到 master 自动交叉编译出 arm64-v8a 无签名 HAP,
打 `v*` tag 时额外发布 GitHub Release。

一次成功构建示例: `https://github.com/panedioic/WineHua/actions/runs/30159227992`

## 变更内容

- `ci/Dockerfile.buildenv`: HarmonyOS 交叉编译环境的 docker image 定义
  (Ubuntu 26.04 + OHOS SDK + 必要的 autotools/cmake/mingw 工具链)
- `.github/workflows/build.yml`: CI workflow, 覆盖 checkout submodules → 交叉编译依赖 →
  构建 Wine/Box64/Mesa → hvigor 打包 HAP → 上传 artifact / 发布 Release

## 使用方式

- **日常 push 到 master**: 自动跑 build, 产出 artifact (保留 14 天), 不发 Release
- **打 tag** (如 `v0.1.0`): build + 自动发布 Release, HAP 作为 asset
- **手动触发**: Actions 页面 `Run workflow`, 可选填 `release_tag`

## 需要注意的点

### 1. 当前用的是我个人的 buildenv 镜像

Workflow 里指向的是 `ghcr.io/panedioic/winehua-buildenv:test`, 这是我推到自己 GHCR 的临时镜像。
后续建议:

- 由 upstream 维护者在 winehua 组织下推一份正式镜像 (比如 `ghcr.io/winehua/winehua-buildenv:latest`)
- Workflow 里的 `container.image` 相应改指过去
- 镜像本身是 pull-through 的, 不影响 fork 用户体验

镜像里已经确认修复了 `libltdl-dev` 依赖问题 (见 Dockerfile 注释), workflow 中的
`Ensure libtool m4 macros present` 兜底 step 是为了防御镜像意外回归, 可视需要保留或删除。

### 2. GitHub Actions 免费额度

Public repo 目前不消耗额度; **Private repo** 免费账户每月 2000 min。
一次完整构建约 50 min, **月内约可跑 40 次**。建议:

- 保留 `paths-ignore` 过滤纯文档 push
- PR 合并前用 draft 状态减少无谓触发
- 上游若长期私有, 考虑扩容或使用 self-hosted runner

### 3. 后续可加速方向: Wine 预编译

一次 50 min 里 **40+ min 都花在 Wine 上**。建议后续:

- 在 `winehua/wine` 仓库里加独立 CI, 按 commit sha 产出预编译产物 (push 到 GHCR OCI artifact
  或作为 wine 仓库的 Release asset)
- 主项目 CI 优先拉取 wine 对应 sha 的预编译包, 拉不到再 fallback 到从源码编译
- 预期整体时间能压到 5~10 min 量级
- 同样思路可推广到 box64 / mesa-ohos 等大依赖

暂时没在这个 PR 里做, 先把主 CI 打通; 后续可单开 issue 讨论方案。

### 4. 目前跳过了签名

- `sign.py` 被 CI stub 替换成 no-op copy
- `build-profile.json5` 由 CI 现场写入, `signingConfigs` 为空数组让 hvigor 跳过 SignHap
- 产出的是 `entry-default-unsigned.hap`, 用户需要开发者模式安装或自行签名

后续可引入真实签名: 把 keystore / profile / 密码放到 GitHub Secrets,
在 CI 里生成一份注入了真实签名信息的 `build-profile.json5`。这块也可以后续单独做。
