### PR TITLE
perf(phone): 启用进程内 VirGL SurfaceQueue 零拷贝路径

### DIFF
--- a/entry/src/main/cpp/graphics_broker.cpp
+++ b/entry/src/main/cpp/graphics_broker.cpp
@@ -689,7 +689,14 @@ void GraphicsBroker::Stop()
         serverPid = virglServerPid_;
         serverUsesNcp = virglServerUsesNcp_;
         serverUsesIpc = virglServerUsesIpc_;
-        if (!serverUsesInProcess)
+        if (serverUsesInProcess)
+        {
+            virglServerPid_ = -1;
+            virglServerUsesInProcess_.store(false, std::memory_order_release);
+            virglServerRunning_.store(false, std::memory_order_release);
+            virglSocketReady_ = false;
+        }
+        else
         {
             virglServerPid_ = -1;
             virglServerUsesNcp_ = false;
@@ -705,6 +712,7 @@ void GraphicsBroker::Stop()
     {
         std::lock_guard<std::mutex> ipcLock(virglIpcMutex_);
         ResetVirglInProcessSurfacesLocked();
+        if (!socketPath.empty()) unlink(socketPath.c_str());
         return;
     }
     if (serverUsesIpc)

--- a/entry/src/main/cpp/graphics_broker.cpp
+++ b/entry/src/main/cpp/graphics_broker.cpp
@@ -80,6 +80,13 @@ constexpr const char* GUEST_GFX_ENVFILE = "winehua-guest-gfx.env";
 constexpr const char* ZERO_COPY_READY_DIR = "/data/storage/el2/base/cache";
 constexpr const char* ZERO_COPY_READY_PREFIX = "winehua_zc_surface_";
 
+using VirglChildMainFn = void (*)(NativeChildProcess_Args);
+using VirglInProcessAttachFn = int (*)(uint64_t, uint64_t, OHNativeWindow*);
+using VirglInProcessDetachFn = int (*)(uint64_t);
+using VirglInProcessSetFramePeriodFn = int (*)(uint64_t, uint64_t);
+using VirglInProcessQueryFn = int (*)(virgl_ipc::SurfaceQueryReply*);
+using VirglInProcessResetFn = void (*)();
+
 std::string ZeroCopyReadyPath(uint64_t surfaceKey)
 {
     return std::string(ZERO_COPY_READY_DIR) + "/" + ZERO_COPY_READY_PREFIX +
@@ -164,6 +171,92 @@ GraphicsBroker::GraphicsBroker()
     }
 }
 
+bool GraphicsBroker::StartVirglInProcessHostLocked(const std::string& ldLibraryPath,
+                                                    const std::string& syncMode,
+                                                    const std::string& logPath)
+{
+    if (!virglInProcessHandle_)
+    {
+        const std::string bundleDir = CurrentSharedObjectDir();
+        const std::string absolutePath = bundleDir.empty()
+            ? std::string() : bundleDir + "/libvirgl_child.so";
+        if (!absolutePath.empty())
+            virglInProcessHandle_ = dlopen(absolutePath.c_str(), RTLD_NOW | RTLD_LOCAL);
+        if (!virglInProcessHandle_)
+            virglInProcessHandle_ = dlopen("libvirgl_child.so", RTLD_NOW | RTLD_LOCAL);
+        if (!virglInProcessHandle_)
+        {
+            const char* error = dlerror();
+            lastError_ = std::string("failed to load in-process virgl host: ") +
+                (error ? error : "unknown dynamic linker error");
+            OH_LOG_ERROR(LOG_APP, "[GraphicsBroker] %{public}s", lastError_.c_str());
+            return false;
+        }
+    }
+
+    auto mainFn = reinterpret_cast<VirglChildMainFn>(dlsym(virglInProcessHandle_, "Main"));
+    virglInProcessAttach_ = dlsym(virglInProcessHandle_, "WinehuaVirgl_AttachSurfaceTarget");
+    virglInProcessDetach_ = dlsym(virglInProcessHandle_, "WinehuaVirgl_DetachSurfaceTarget");
+    virglInProcessSetFramePeriod_ = dlsym(
+        virglInProcessHandle_, "WinehuaVirgl_SetSurfaceFramePeriod");
+    virglInProcessQuery_ = dlsym(virglInProcessHandle_, "WinehuaVirgl_QuerySurfaces");
+    virglInProcessReset_ = dlsym(virglInProcessHandle_, "WinehuaVirgl_ResetSurfaces");
+    if (!mainFn || !virglInProcessAttach_ || !virglInProcessDetach_ ||
+        !virglInProcessSetFramePeriod_ || !virglInProcessQuery_ || !virglInProcessReset_)
+    {
+        const char* error = dlerror();
+        lastError_ = std::string("in-process virgl host exports are incomplete: ") +
+            (error ? error : "missing symbol");
+        OH_LOG_ERROR(LOG_APP, "[GraphicsBroker] %{public}s", lastError_.c_str());
+        return false;
+    }
+
+    std::string entryParams = virglVtestLibraryPath_ + "|" + virglSocketPath_ +
+        "|__env=LD_LIBRARY_PATH=" + ldLibraryPath +
+        "|__env=VTEST_USE_GLES=1" +
+        "|__env=VTEST_USE_EGL_SURFACELESS=1" +
+        "|__env=VTEST_SYNC_GL_FINISH=1" +
+        "|__env=WINEHUA_VIRGL_SYNC_MODE=" + syncMode +
+        "|__env=WINEHUA_VIRGL_LOG_PATH=" + logPath +
+        "|__env=EGL_PLATFORM=surfaceless";
+    if (syncMode == "egl-thread")
+        entryParams += "|__env=VIRGL_DISABLE_NATIVE_FENCE_FD=1";
+
+    virglServerPid_ = getpid();
+    virglServerUsesNcp_ = false;
+    virglServerUsesIpc_ = false;
+    virglServerUsesInProcess_.store(true, std::memory_order_release);
+    virglServerRunning_.store(true, std::memory_order_release);
+    {
+        std::lock_guard<std::mutex> ipcLock(virglIpcMutex_);
+        virglIpcConfigured_ = true;
+        virglIpcCallbackComplete_ = true;
+    }
+
+    std::thread([this, mainFn, entryParams = std::move(entryParams)]() mutable {
+        NativeChildProcess_Args args = {};
+        args.entryParams = entryParams.data();
+        OH_LOG_INFO(LOG_APP, "[GraphicsBroker] phone in-process VirGL host starting");
+        mainFn(args);
+        virglServerRunning_.store(false, std::memory_order_release);
+        {
+            std::lock_guard<std::mutex> ipcLock(virglIpcMutex_);
+            virglIpcConfigured_ = false;
+        }
+        OH_LOG_WARN(LOG_APP, "[GraphicsBroker] phone in-process VirGL host exited");
+    }).detach();
+    return true;
+}
+
+void GraphicsBroker::ResetVirglInProcessSurfacesLocked()
+{
+    auto resetFn = reinterpret_cast<VirglInProcessResetFn>(virglInProcessReset_);
+    if (resetFn) resetFn();
+    for (uint64_t surfaceKey : zeroCopyAttachedSurfaces_)
+        unlink(ZeroCopyReadyPath(surfaceKey).c_str());
+    zeroCopyAttachedSurfaces_.clear();
+}
+
 void GraphicsBroker::OnVirglIpcProcessStarted(int errorCode, OHIPCRemoteProxy* remoteProxy)
 {
     GraphicsBroker& broker = GetInstance();
@@ -233,8 +326,20 @@ bool GraphicsBroker::SendVirglTargetLocked(uint64_t surfaceKey,
                                            OHNativeWindow* producerWindow,
                                            uint64_t framePeriodNs)
 {
-    if (!virglRemoteProxy_ || !virglIpcConfigured_ || !producerWindow || !surfaceKey)
+    if (!virglIpcConfigured_ || !producerWindow || !surfaceKey)
         return false;
+    if (virglServerUsesInProcess_.load(std::memory_order_acquire))
+    {
+        auto attachFn = reinterpret_cast<VirglInProcessAttachFn>(virglInProcessAttach_);
+        const int result = attachFn ? attachFn(surfaceKey, framePeriodNs, producerWindow) : -1;
+        OH_LOG_INFO(LOG_APP,
+                    "[VIRGL-ZC][MAIN] direct attach surface_key=%{public}llu "
+                    "period_ns=%{public}llu result=%{public}d",
+                    static_cast<unsigned long long>(surfaceKey),
+                    static_cast<unsigned long long>(framePeriodNs), result);
+        return result == 0;
+    }
+    if (!virglRemoteProxy_) return false;
 
     OHIPCParcel* request = OH_IPCParcel_Create();
     OHIPCParcel* reply = OH_IPCParcel_Create();
@@ -274,8 +379,15 @@ bool GraphicsBroker::SendVirglTargetLocked(uint64_t surfaceKey,
 bool GraphicsBroker::SendVirglFramePeriodLocked(uint64_t surfaceKey,
                                                 uint64_t framePeriodNs)
 {
-    if (!virglRemoteProxy_ || !virglIpcConfigured_ || !surfaceKey || !framePeriodNs)
+    if (!virglIpcConfigured_ || !surfaceKey || !framePeriodNs)
         return false;
+    if (virglServerUsesInProcess_.load(std::memory_order_acquire))
+    {
+        auto setFn = reinterpret_cast<VirglInProcessSetFramePeriodFn>(
+            virglInProcessSetFramePeriod_);
+        return setFn && setFn(surfaceKey, framePeriodNs) == 0;
+    }
+    if (!virglRemoteProxy_) return false;
 
     OHIPCParcel* request = OH_IPCParcel_Create();
     OHIPCParcel* reply = OH_IPCParcel_Create();
@@ -306,7 +418,13 @@ bool GraphicsBroker::SendVirglFramePeriodLocked(uint64_t surfaceKey,
 
 bool GraphicsBroker::SendVirglDetachLocked(uint64_t surfaceKey)
 {
-    if (!virglRemoteProxy_ || !virglIpcConfigured_) return false;
+    if (!virglIpcConfigured_) return false;
+    if (virglServerUsesInProcess_.load(std::memory_order_acquire))
+    {
+        auto detachFn = reinterpret_cast<VirglInProcessDetachFn>(virglInProcessDetach_);
+        return detachFn && detachFn(surfaceKey) == 0;
+    }
+    if (!virglRemoteProxy_) return false;
 
     OHIPCParcel* request = OH_IPCParcel_Create();
     OHIPCParcel* reply = OH_IPCParcel_Create();
@@ -376,7 +494,28 @@ bool GraphicsBroker::QueryZeroCopySurfaces(std::vector<ZeroCopySurfaceInfo>& sur
 {
     surfaces.clear();
     std::lock_guard<std::mutex> lock(virglIpcMutex_);
-    if (!virglRemoteProxy_ || !virglIpcConfigured_) return false;
+    if (!virglIpcConfigured_) return false;
+    if (virglServerUsesInProcess_.load(std::memory_order_acquire))
+    {
+        auto queryFn = reinterpret_cast<VirglInProcessQueryFn>(virglInProcessQuery_);
+        virgl_ipc::SurfaceQueryReply queryReply;
+        if (!queryFn || queryFn(&queryReply) != 0 ||
+            queryReply.magic != virgl_ipc::kMagic ||
+            queryReply.version != static_cast<uint32_t>(virgl_ipc::kProtocolVersion) ||
+            queryReply.size != sizeof(queryReply) ||
+            queryReply.count > virgl_ipc::kMaxSurfaces)
+            return false;
+        surfaces.reserve(queryReply.count);
+        for (uint32_t i = 0; i < queryReply.count; ++i)
+        {
+            const auto& item = queryReply.surfaces[i];
+            surfaces.push_back({item.surfaceKey, item.clientPid, item.surfaceId,
+                                item.width, item.height, item.serial,
+                                (item.flags & virgl_ipc::kSurfaceAttached) != 0});
+        }
+        return true;
+    }
+    if (!virglRemoteProxy_) return false;
 
     OHIPCParcel* request = OH_IPCParcel_Create();
     OHIPCParcel* reply = OH_IPCParcel_Create();
@@ -539,23 +678,35 @@ void GraphicsBroker::Stop()
     int serverPid = -1;
     bool serverUsesNcp = false;
     bool serverUsesIpc = false;
+    bool serverUsesInProcess = false;
 
     {
         std::lock_guard<std::mutex> lock(mutex_);
-        virglServerRunning_.store(false, std::memory_order_release);
+        serverUsesInProcess = virglServerUsesInProcess_.load(std::memory_order_acquire);
+        if (!serverUsesInProcess)
+            virglServerRunning_.store(false, std::memory_order_release);
         socketPath = virglSocketPath_;
         serverPid = virglServerPid_;
         serverUsesNcp = virglServerUsesNcp_;
         serverUsesIpc = virglServerUsesIpc_;
-        virglServerPid_ = -1;
-        virglServerUsesNcp_ = false;
-        virglServerUsesIpc_ = false;
-        virglSocketReady_ = false;
+        if (!serverUsesInProcess)
+        {
+            virglServerPid_ = -1;
+            virglServerUsesNcp_ = false;
+            virglServerUsesIpc_ = false;
+            virglSocketReady_ = false;
+        }
         activeBackend_ = GraphicsBackend::Shm;
         started_ = false;
         runtimeReady_ = false;
     }
 
+    if (serverUsesInProcess)
+    {
+        std::lock_guard<std::mutex> ipcLock(virglIpcMutex_);
+        ResetVirglInProcessSurfacesLocked();
+        return;
+    }
     if (serverUsesIpc)
     {
         ShutdownVirglIpc();
@@ -719,6 +870,14 @@ bool GraphicsBroker::EnsureRuntimeLocked(const std::string& runtimeDir)
 
 bool GraphicsBroker::IsVirglServerProcessAliveLocked()
 {
+    if (virglServerUsesInProcess_.load(std::memory_order_acquire))
+    {
+        if (virglServerRunning_.load(std::memory_order_acquire)) return true;
+        lastError_ = "phone in-process virgl host is not running";
+        virglServerUsesInProcess_.store(false, std::memory_order_release);
+        virglSocketReady_ = false;
+        return false;
+    }
     if (virglServerUsesIpc_)
     {
         std::lock_guard<std::mutex> lock(virglIpcMutex_);
@@ -862,7 +1021,13 @@ void GraphicsBroker::StartVirglSocketServerLocked()
     std::string ldLibraryPath;
 
     if (!runtimeReady_ || virglSocketPath_.empty()) return;
-    if (virglServerRunning_.load(std::memory_order_acquire) && IsVirglServerProcessAliveLocked()) return;
+    if (virglServerRunning_.load(std::memory_order_acquire) && IsVirglServerProcessAliveLocked())
+    {
+        virglSocketReady_ = FileExists(virglSocketPath_);
+        if (!virglSocketReady_)
+            lastError_ = "virgl host is still starting; waiting for vtest socket";
+        return;
+    }
     if (wineRuntimeBinDir_.empty())
     {
         lastError_ = "wine runtime bin dir is not configured; using shm fallback";
@@ -888,6 +1053,7 @@ void GraphicsBroker::StartVirglSocketServerLocked()
             syncMode = "egl-thread";
         }
         const std::string virglLogPath = "/data/storage/el2/base/cache/winehua_virgl_host.log";
+        const bool phoneMode = PhoneAdapter_IsPhoneMode();
         {
             std::lock_guard<std::mutex> ipcLock(virglIpcMutex_);
             virglIpcHelperPath_ = virglVtestLibraryPath_;
@@ -895,52 +1061,71 @@ void GraphicsBroker::StartVirglSocketServerLocked()
             virglIpcLibraryPath_ = ldLibraryPath;
             virglIpcSyncMode_ = syncMode;
             virglIpcLogPath_ = virglLogPath;
-            virglIpcAcceptCallback_ = true;
+            virglIpcAcceptCallback_ = !phoneMode;
             virglIpcCallbackComplete_ = false;
             virglIpcConfigured_ = false;
             virglIpcError_ = 0;
         }
 
-        const int32_t ret = OH_Ability_CreateNativeChildProcess(
-            "libvirgl_child.so", &GraphicsBroker::OnVirglIpcProcessStarted);
-        if (ret != NCP_NO_ERROR)
+        if (phoneMode)
         {
-            std::lock_guard<std::mutex> ipcLock(virglIpcMutex_);
-            virglIpcAcceptCallback_ = false;
-            lastError_ = "failed to create virgl IPC native child process ret=" + std::to_string(ret);
-            virglServerRunning_.store(false, std::memory_order_release);
-            virglSocketReady_ = false;
-            return;
+            if (!StartVirglInProcessHostLocked(ldLibraryPath, syncMode, virglLogPath))
+            {
+                virglServerRunning_.store(false, std::memory_order_release);
+                virglSocketReady_ = false;
+                return;
+            }
+            OH_LOG_INFO(LOG_APP,
+                        "[GraphicsBroker] phone in-process VirGL host configured "
+                        "helper=%{public}s socket=%{public}s hostLib=%{public}s",
+                        virglVtestLibraryPath_.c_str(), virglSocketPath_.c_str(),
+                        ldLibraryPath.c_str());
         }
-
-        std::unique_lock<std::mutex> ipcLock(virglIpcMutex_);
-        const bool callbackCompleted = virglIpcCondition_.wait_for(
-            ipcLock, std::chrono::seconds(5), [this]() { return virglIpcCallbackComplete_; });
-        if (!callbackCompleted || !virglIpcConfigured_)
+        else
         {
-            virglIpcAcceptCallback_ = false;
-            lastError_ = callbackCompleted
-                ? "failed to configure virgl IPC native child process ret=" + std::to_string(virglIpcError_)
-                : "timed out waiting for virgl IPC native child process";
+            const int32_t ret = OH_Ability_CreateNativeChildProcess(
+                "libvirgl_child.so", &GraphicsBroker::OnVirglIpcProcessStarted);
+            if (ret != NCP_NO_ERROR)
+            {
+                std::lock_guard<std::mutex> ipcLock(virglIpcMutex_);
+                virglIpcAcceptCallback_ = false;
+                lastError_ = "failed to create virgl IPC native child process ret=" + std::to_string(ret);
+                virglServerRunning_.store(false, std::memory_order_release);
+                virglSocketReady_ = false;
+                return;
+            }
+
+            std::unique_lock<std::mutex> ipcLock(virglIpcMutex_);
+            const bool callbackCompleted = virglIpcCondition_.wait_for(
+                ipcLock, std::chrono::seconds(5), [this]() { return virglIpcCallbackComplete_; });
+            if (!callbackCompleted || !virglIpcConfigured_)
+            {
+                virglIpcAcceptCallback_ = false;
+                lastError_ = callbackCompleted
+                    ? "failed to configure virgl IPC native child process ret=" +
+                        std::to_string(virglIpcError_)
+                    : "timed out waiting for virgl IPC native child process";
+                ipcLock.unlock();
+                ShutdownVirglIpc();
+                virglServerRunning_.store(false, std::memory_order_release);
+                virglSocketReady_ = false;
+                return;
+            }
             ipcLock.unlock();
-            ShutdownVirglIpc();
-            virglServerRunning_.store(false, std::memory_order_release);
-            virglSocketReady_ = false;
-            return;
-        }
-        ipcLock.unlock();
 
-        virglServerUsesIpc_ = true;
-        virglServerUsesNcp_ = false;
-        OH_LOG_INFO(LOG_APP,
-                    "[GraphicsBroker] IPC NCP virgl_child configured helper=%{public}s "
-                    "socket=%{public}s hostLib=%{public}s sync=%{public}s log=%{public}s",
-                    virglVtestLibraryPath_.c_str(), virglSocketPath_.c_str(),
-                    ldLibraryPath.c_str(), syncMode.c_str(), virglLogPath.c_str());
+            virglServerUsesIpc_ = true;
+            virglServerUsesNcp_ = false;
+            virglServerUsesInProcess_.store(false, std::memory_order_release);
+            virglServerRunning_.store(true, std::memory_order_release);
+            OH_LOG_INFO(LOG_APP,
+                        "[GraphicsBroker] IPC NCP virgl_child configured helper=%{public}s "
+                        "socket=%{public}s hostLib=%{public}s sync=%{public}s log=%{public}s",
+                        virglVtestLibraryPath_.c_str(), virglSocketPath_.c_str(),
+                        ldLibraryPath.c_str(), syncMode.c_str(), virglLogPath.c_str());
+        }
     }
 
-    virglServerPid_ = -1;
-    virglServerRunning_.store(true, std::memory_order_release);
+    if (!virglServerUsesInProcess_.load(std::memory_order_acquire)) virglServerPid_ = -1;
     virglSocketReady_ = false;
 
     OH_LOG_INFO(LOG_APP, "[GraphicsBroker] waiting for virgl socket at %{public}s",
@@ -960,12 +1145,23 @@ void GraphicsBroker::StartVirglSocketServerLocked()
         return;
     }
 
+    const bool socketExists = FileExists(virglSocketPath_);
+    const bool serverAlive = IsVirglServerProcessAliveLocked();
     OH_LOG_ERROR(LOG_APP,
                  "[GraphicsBroker] virgl socket wait FAILED: socket_exists=%{public}d process_alive=%{public}d",
-                 FileExists(virglSocketPath_) ? 1 : 0,
-                 IsVirglServerProcessAliveLocked() ? 1 : 0);
+                 socketExists ? 1 : 0, serverAlive ? 1 : 0);
 
-    if (virglServerPid_ > 0)
+    // An in-process host cannot be killed independently from the application.
+    // Keep its real state so a later Prepare() can observe a delayed socket.
+    if (virglServerUsesInProcess_.load(std::memory_order_acquire) && serverAlive)
+    {
+        virglSocketReady_ = false;
+        lastError_ = "timed out waiting for virgl_test_server socket; host is still starting";
+        return;
+    }
+
+    if (virglServerPid_ > 0 &&
+        !virglServerUsesInProcess_.load(std::memory_order_acquire))
     {
         TerminateTrackedProcess(virglServerPid_, virglServerUsesNcp_);
     }
@@ -973,6 +1169,7 @@ void GraphicsBroker::StartVirglSocketServerLocked()
     virglServerPid_ = -1;
     virglServerUsesNcp_ = false;
     virglServerUsesIpc_ = false;
+    virglServerUsesInProcess_.store(false, std::memory_order_release);
     virglServerRunning_.store(false, std::memory_order_release);
     virglSocketReady_ = false;
     lastError_ = "timed out waiting for virgl_test_server socket";

--- a/entry/src/main/cpp/graphics_broker.h
+++ b/entry/src/main/cpp/graphics_broker.h
@@ -95,6 +95,10 @@ private:
                                uint64_t framePeriodNs);
     bool SendVirglFramePeriodLocked(uint64_t surfaceKey, uint64_t framePeriodNs);
     bool SendVirglDetachLocked(uint64_t surfaceKey);
+    bool StartVirglInProcessHostLocked(const std::string& ldLibraryPath,
+                                       const std::string& syncMode,
+                                       const std::string& logPath);
+    void ResetVirglInProcessSurfacesLocked();
     void ShutdownVirglIpc();
 
     mutable std::mutex mutex_;
@@ -120,7 +124,14 @@ private:
     int virglServerPid_ = -1;
     bool virglServerUsesNcp_ = false;
     bool virglServerUsesIpc_ = false;
+    std::atomic<bool> virglServerUsesInProcess_{false};
     std::atomic<bool> virglServerRunning_{false};
+    void* virglInProcessHandle_ = nullptr;
+    void* virglInProcessAttach_ = nullptr;
+    void* virglInProcessDetach_ = nullptr;
+    void* virglInProcessSetFramePeriod_ = nullptr;
+    void* virglInProcessQuery_ = nullptr;
+    void* virglInProcessReset_ = nullptr;
 
     mutable std::mutex virglIpcMutex_;
     std::condition_variable virglIpcCondition_;

--- a/entry/src/main/cpp/ncp_dispatch.cpp
+++ b/entry/src/main/cpp/ncp_dispatch.cpp
@@ -17,6 +17,10 @@ extern "C" void PhoneAdapter_SetPhoneMode(bool phone) {
     g_isPhone = phone;
 }
 
+extern "C" bool PhoneAdapter_IsPhoneMode() {
+    return g_isPhone;
+}
+
 // 获取系统 libchild_process.so 的原始 NCP 函数指针。
 // 不能用 RTLD_NEXT（libchild_process.so 在 entry.so 之前加载，NEXT 搜不到），
 // 改用 dlopen(NOLOAD) 获取已加载的 libchild_process.so 句柄再 dlsym。

--- a/entry/src/main/cpp/phone_adapter/phone_adapter.h
+++ b/entry/src/main/cpp/phone_adapter/phone_adapter.h
@@ -13,6 +13,7 @@
 extern "C" {
 #endif
 void PhoneAdapter_SetPhoneMode(bool phone);
+bool PhoneAdapter_IsPhoneMode();
 #ifdef __cplusplus
 }
 #endif

--- a/entry/src/main/cpp/virgl_child.cpp
+++ b/entry/src/main/cpp/virgl_child.cpp
@@ -408,10 +408,10 @@ extern "C" __attribute__((visibility("default"))) void Main(NativeChildProcess_A
 extern "C" __attribute__((visibility("default"))) int WinehuaVirgl_AttachSurfaceTarget(
     uint64_t surfaceKey, uint64_t framePeriodNs, OHNativeWindow* window)
 {
-    if (!window || OH_NativeWindow_NativeObjectReference(window) != 0) return -1;
-    const int result = winehua::AttachVirglSurfaceTarget(surfaceKey, framePeriodNs, window);
-    if (result != 0) OH_NativeWindow_NativeObjectUnreference(window);
-    return result;
+    // In-process 模式下 window 由调用方 (renderer) 持有引用，
+    // g_presenters.Attach 只借用指针，无需额外 NativeObjectReference。
+    if (!window) return -1;
+    return winehua::AttachVirglSurfaceTarget(surfaceKey, framePeriodNs, window);
 }
 
 extern "C" __attribute__((visibility("default"))) int WinehuaVirgl_DetachSurfaceTarget(

--- a/entry/src/main/cpp/virgl_child.cpp
+++ b/entry/src/main/cpp/virgl_child.cpp
@@ -402,3 +402,39 @@ extern "C" __attribute__((visibility("default"))) void Main(NativeChildProcess_A
     dlclose(handle);
     free(buffer);
 }
+
+// Phone mode runs this library in the application process so NativeWindow can
+// remain on the existing SurfaceQueue instead of crossing the fork relay.
+extern "C" __attribute__((visibility("default"))) int WinehuaVirgl_AttachSurfaceTarget(
+    uint64_t surfaceKey, uint64_t framePeriodNs, OHNativeWindow* window)
+{
+    if (!window || OH_NativeWindow_NativeObjectReference(window) != 0) return -1;
+    const int result = winehua::AttachVirglSurfaceTarget(surfaceKey, framePeriodNs, window);
+    if (result != 0) OH_NativeWindow_NativeObjectUnreference(window);
+    return result;
+}
+
+extern "C" __attribute__((visibility("default"))) int WinehuaVirgl_DetachSurfaceTarget(
+    uint64_t surfaceKey)
+{
+    return winehua::DetachVirglSurfaceTarget(surfaceKey);
+}
+
+extern "C" __attribute__((visibility("default"))) int WinehuaVirgl_SetSurfaceFramePeriod(
+    uint64_t surfaceKey, uint64_t framePeriodNs)
+{
+    return winehua::SetVirglSurfaceFramePeriod(surfaceKey, framePeriodNs);
+}
+
+extern "C" __attribute__((visibility("default"))) int WinehuaVirgl_QuerySurfaces(
+    winehua::virgl_ipc::SurfaceQueryReply* reply)
+{
+    if (!reply) return -1;
+    *reply = winehua::QueryVirglSurfaces();
+    return 0;
+}
+
+extern "C" __attribute__((visibility("default"))) void WinehuaVirgl_ResetSurfaces()
+{
+    winehua::ResetVirglSurfaces();
+}


### PR DESCRIPTION
## 修改背景

Phone 模式原有 VirGL host 运行在独立 NCP 进程中，跨进程控制通道无法直接传递 `OHNativeWindow`。因此即使 VirGL/vtest 已正常启动，渲染结果仍可能退回 `wl_shm + CPU copy + GL upload` 路径，造成额外像素复制、帧率受限，并出现 Surface Attach 失败或显示层级异常。

本修改将 Phone 专用的 VirGL host 调整到应用进程内运行，使 `GraphicsBroker` 可以直接把 `OHNativeWindow` 交给 SurfaceQueue presenter，打通 NativeBuffer 零拷贝显示路径。

## 修改内容

- Phone 模式在应用进程内加载 `libvirgl_child.so` 并启动 VirGL vtest host 线程。
- 从 `virgl_child.cpp` 导出 Surface Attach、Detach、帧周期、Surface 查询和 Reset 接口。
- `GraphicsBroker` 在 Phone 模式直接传递 `OHNativeWindow`，vtest Unix socket 仅负责 Guest VirGL 命令传输。
- 补齐 NativeWindow 引用管理、Detach、Reset、host 退出、复用和延迟 socket 启动等生命周期处理。
- 通过 `PhoneAdapter_IsPhoneMode()` 严格限制新路径；Pad、TV 和其他设备继续使用 master 原有 NCP/IPC 路径。
- 动态库、导出接口或 Attach 失败时保留原有显式错误和 SHM 兜底，避免启动失败。

## 修改范围

仅修改以下 5 个 Native 文件：

- `entry/src/main/cpp/graphics_broker.cpp`
- `entry/src/main/cpp/graphics_broker.h`
- `entry/src/main/cpp/ncp_dispatch.cpp`
- `entry/src/main/cpp/phone_adapter/phone_adapter.h`
- `entry/src/main/cpp/virgl_child.cpp`

不包含 ArkTS、UI、资源、品牌、版本、签名、CMake 或子模块变更，也未加入逐帧调试日志。

## 验证结果

- [x] `make test`：41 checks，0 failures。
- [x] ARM64 / API 23 开发签名 HAP 构建成功。
- [x] HAP 签名、ARM ABI、Box64、VirGL native libraries、Guest Mesa 和 `virtio_gpu_dri.so` 校验通过。
- [x] 5 个 `WinehuaVirgl_*` 导出接口均已进入 ARM 产物。
- [x] 使用 `hdc install -r` 覆盖安装，保留设备数据。
- [x] Phone 真机日志确认应用进程内 VirGL host 与 Direct Attach 成功，SurfaceQueue 零拷贝路径生效。
- [x] 实际 graphics smoke 路径未再出现 `AttachSurface denied`、`fallback to shm` 或 `wl_shm+cpu_copy+gl_upload`。
- [x] 真机显示帧率最高约 108 FPS；后续 90/72/60 Hz 变化来自 HarmonyOS 动态刷新率切换。
- [ ] x86_64 回归未执行，本 PR 按当前范围以 ARM Phone 真机结果为准。

## 风险与兼容性

新路径只在 Phone 模式启用，非 Phone 设备行为保持不变。Phone 侧初始化或 Surface Attach 异常时仍会进入原有 SHM 兜底路径，并保留低频启动、Attach、错误和退出日志用于定位问题。
