### PR TITLE
feat(x86_64/emulator): route guest graphics through software rendering (OpenGL smoke on PC emulator)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,10 @@ entry/src/main/resources/rawfile/wine-data.zip
 entry/src/main/resources/rawfile/wine-runtime-manifest.json
 tmp/
 prebuilt/
+
+# Local signing material (never commit)
+/sign/
+
+# Python caches
+__pycache__/
+*.pyc

--- a/entry/src/main/cpp/graphics_broker.cpp
+++ b/entry/src/main/cpp/graphics_broker.cpp
@@ -888,11 +888,10 @@ void GraphicsBroker::AppendWineEnv(std::vector<std::string>& env) const
                           "libwayland-server.so.0:libwayland-egl.so:libwayland-egl.so.1:"
                           "libdrm.so:libdrm.so.2:libffi.so:libffi.so.8");
 #endif
-            if (DirExists(guestLibDir + "/dri"))
 #ifdef __x86_64__
-                env.push_back("LIBGL_DRIVERS_PATH=/data/storage/el1/bundle/libs/x86_64");
+            // LIBGL_DRIVERS_PATH 由下方 softpipe 块统一指向 el1, 不在此重复设置
 #else
-                env.push_back("LIBGL_DRIVERS_PATH=" + guestLibDir + "/dri");
+            if (DirExists(guestLibDir + "/dri")) env.push_back("LIBGL_DRIVERS_PATH=" + guestLibDir + "/dri");
 #endif
             if (DirExists(guestLibDir + "/egl")) env.push_back("EGL_DRIVERS_PATH=" + guestLibDir + "/egl");
         }

--- a/entry/src/main/cpp/graphics_broker.cpp
+++ b/entry/src/main/cpp/graphics_broker.cpp
@@ -874,7 +874,11 @@ void GraphicsBroker::AppendWineEnv(std::vector<std::string>& env) const
             std::string guestLibDir = state.guestReceiverRuntimeDir + "/lib";
             env.push_back("EGL_PLATFORM=wayland");
             if (FileExists(guestLibDir + "/libEGL.so"))
+#ifdef __x86_64__
+                env.push_back("WINEHUA_EGL_LIBRARY_PATH=/data/storage/el1/bundle/libs/x86_64/libEGL.so");
+#else
                 env.push_back("WINEHUA_EGL_LIBRARY_PATH=" + guestLibDir + "/libEGL.so");
+#endif
 #ifdef __aarch64__
             // NOTE: 非 DXVK 基线值 (8 个 lib, 不含 libvulkan)。
             // DXVK 路径下 AppendD3dBackendEnv 会用 14 个 lib (含 libvulkan) 覆盖此值。
@@ -884,7 +888,12 @@ void GraphicsBroker::AppendWineEnv(std::vector<std::string>& env) const
                           "libwayland-server.so.0:libwayland-egl.so:libwayland-egl.so.1:"
                           "libdrm.so:libdrm.so.2:libffi.so:libffi.so.8");
 #endif
-            if (DirExists(guestLibDir + "/dri")) env.push_back("LIBGL_DRIVERS_PATH=" + guestLibDir + "/dri");
+            if (DirExists(guestLibDir + "/dri"))
+#ifdef __x86_64__
+                env.push_back("LIBGL_DRIVERS_PATH=/data/storage/el1/bundle/libs/x86_64");
+#else
+                env.push_back("LIBGL_DRIVERS_PATH=" + guestLibDir + "/dri");
+#endif
             if (DirExists(guestLibDir + "/egl")) env.push_back("EGL_DRIVERS_PATH=" + guestLibDir + "/egl");
         }
         env.push_back("WINEHUA_WAYLAND_READBACK=1");
@@ -894,7 +903,17 @@ void GraphicsBroker::AppendWineEnv(std::vector<std::string>& env) const
         env.push_back("WINEHUA_VTEST_PRESENT=surface-queue");
         env.push_back(std::string("WINEHUA_ZERO_COPY_READY_DIR=") + ZERO_COPY_READY_DIR);
         for (const std::string& extra : guestEnv) env.push_back(extra);
+#ifdef __x86_64__
+        // HarmonyOS PC emulator express GPU cannot host GL: eglCreateContext
+        // with a NULL share context and glTexImage2D with NULL pixels crash
+        // Emulator.exe. Route the x86_64 guest to software rendering
+        // (softpipe) instead of virpipe, and do not advertise the vtest
+        // socket. arm64 real-device virgl path is unchanged.
+        env.push_back("GALLIUM_DRIVER=softpipe");
+        env.push_back("LIBGL_DRIVERS_PATH=/data/storage/el1/bundle/libs/x86_64");
+#else
         if (!state.virglSocketPath.empty()) env.push_back("VTEST_SOCKET_NAME=" + state.virglSocketPath);
+#endif
     }
 }
 

--- a/entry/src/main/cpp/graphics_broker.cpp
+++ b/entry/src/main/cpp/graphics_broker.cpp
@@ -11,6 +11,7 @@
 #include <IPCKit/ipc_kit.h>
 #include <native_window/external_window.h>
 #include "virgl_ipc_protocol.h"
+#include "wine_env.h"
 
 // ---- 与 OH_IPCRemoteProxy_* 签名兼容的包装：真 proxy 走原 API，dummy 走 socket relay ----
 static int SendVirglRequestLocked(OHIPCRemoteProxy* proxy, uint32_t code,
@@ -908,8 +909,13 @@ void GraphicsBroker::AppendWineEnv(std::vector<std::string>& env) const
         // Emulator.exe. Route the x86_64 guest to software rendering
         // (softpipe) instead of virpipe, and do not advertise the vtest
         // socket. arm64 real-device virgl path is unchanged.
-        env.push_back("GALLIUM_DRIVER=softpipe");
-        env.push_back("LIBGL_DRIVERS_PATH=/data/storage/el1/bundle/libs/x86_64");
+        //
+        // NOTE: 必须用 UpsertEnvLine 覆盖而不是 push_back — guest_gfx env
+        // 文件 (共享产物, arm64/x86_64 同一份) 里已含 GALLIUM_DRIVER=virpipe
+        // 与 LIBGL_DRIVERS_PATH=$ORIGIN/lib/dri, 而 getenv 取首个匹配项,
+        // push_back 追加的 softpipe/el1 值会被产物里的旧值遮蔽。
+        UpsertEnvLine(env, "GALLIUM_DRIVER=softpipe");
+        UpsertEnvLine(env, "LIBGL_DRIVERS_PATH=/data/storage/el1/bundle/libs/x86_64");
 #else
         if (!state.virglSocketPath.empty()) env.push_back("VTEST_SOCKET_NAME=" + state.virglSocketPath);
 #endif

--- a/entry/src/main/cpp/virgl_child.cpp
+++ b/entry/src/main/cpp/virgl_child.cpp
@@ -502,7 +502,12 @@ extern "C" __attribute__((visibility("default"))) OHIPCRemoteStub* NativeChildPr
 extern "C" __attribute__((visibility("default"))) void NativeChildProcess_MainProc()
 {
     ClearGuestGraphicsEnv();
+#ifdef __x86_64__
+    // Emulator express GPU: surfaceless EGL crashes it; use default display
+    setenv("EGL_PLATFORM", "default", 1);
+#else
     setenv("EGL_PLATFORM", "surfaceless", 1);
+#endif
     // 手机适配层：启动 socket dispatch 线程，替代 Binder 驱动回调
     {
         const char* fdEnv = getenv("WINEHUA_PHONE_CFG_FD");
@@ -659,12 +664,20 @@ extern "C" __attribute__((visibility("default"))) void Main(NativeChildProcess_A
     char arg0[] = "virgl_test_server";
     char arg1[] = "--no-fork";
     char arg2[] = "--multi-clients";
+#ifdef __x86_64__
+    // Emulator express GPU: surfaceless EGL crashes it; use default display + GLES
+    char arg3[] = "--use-gles";
+    char* argv[] = {arg0, arg1, arg2, arg3, "--socket-path", socketPath, nullptr};
+#else
     char arg3[] = "--use-egl-surfaceless";
     char arg4[] = "--use-gles";
-    char arg5[] = "--venus";
-    char arg6[] = "--socket-path";
-    char* argv[] = {arg0, arg1, arg2, arg3, arg4, arg5, arg6, socketPath, nullptr};
+    char* argv[] = {arg0, arg1, arg2, arg3, arg4, "--venus", "--socket-path", socketPath, nullptr};
+#endif
+#ifdef __x86_64__
+    int rc = vtestMain(6, argv);
+#else
     int rc = vtestMain(8, argv);
+#endif
 
     OH_LOG_WARN(LOG_APP, "[virgl-child] vtest exited rc=%{public}d", rc);
     if (setVulkanDeviceReleaseCallback)

--- a/entry/src/main/cpp/wine_child.cpp
+++ b/entry/src/main/cpp/wine_child.cpp
@@ -265,7 +265,9 @@ static void setup_wine_env(const char* binDir, const char* homeDir, const char *
     setenv("BOX64_LD_LIBRARY_PATH", libDir.c_str(), 1);
 #else
     // x86_64: 系统 linker 直接加载 x86_64 OHOS .so
-    setenv("LD_LIBRARY_PATH", libDir.c_str(), 1);
+    // guest_gfx 库已打包进 bundle libs (el1, 系统 dlopen 允许), 依赖也从该目录解析
+    setenv("LD_LIBRARY_PATH",
+           (libDir + ":/data/storage/el1/bundle/libs/x86_64").c_str(), 1);
 #endif
 
     if (homeDir && homeDir[0])

--- a/scripts/assemble.sh
+++ b/scripts/assemble.sh
@@ -472,6 +472,23 @@ HKLM,%FontSubStr%,"Lucida Console",,"Noto Sans Mono"' "$wine_data/share/wine/win
         log "  guest_gfx: SKIP (build/guest_gfx/$guest_arch/lib not found)"
     fi
 
+    # x86_64: guest Mesa 库必须可被系统 dlopen (el1 bundle libs); el2 数据区 dlopen 被拒 (ENOENT).
+    # 仅复制 host libs 中不存在的 guest 专用库, 共享依赖 (libwayland-*/libffi/libz/libc++_shared)
+    # 直接复用 el1 中已有的 host 版本.
+    if [ "$NATIVE_ARCH" = "x86_64" ] && [ -d "$BUILD_DIR/guest_gfx/$guest_arch/lib" ]; then
+        log "  guest_gfx -> entry/libs/x86_64 (el1 dlopen for x86_64)"
+        mkdir -p "$ROOT/entry/libs/x86_64"
+        for pattern in libEGL.so libGLESv2.so libGLESv1_CM.so libgallium-*.so libdrm.so; do
+            for f in "$BUILD_DIR/guest_gfx/$guest_arch/lib"/$pattern*; do
+                [ -f "$f" ] && cp -a "$f" "$ROOT/entry/libs/x86_64/"
+            done
+        done
+        for f in "$BUILD_DIR/guest_gfx/$guest_arch/lib"/dri/*.so; do
+            [ -f "$f" ] && cp -a "$f" "$ROOT/entry/libs/x86_64/"
+        done
+        log "  guest_gfx el1: $(ls "$ROOT/entry/libs/x86_64"/libEGL.so* "$ROOT/entry/libs/x86_64"/libgallium-*.so 2>/dev/null | wc -l) libs + $(ls "$ROOT/entry/libs/x86_64"/*_dri.so 2>/dev/null | wc -l) dri drivers"
+    fi
+
     # Guest Linux Vulkan runtime is intentionally outside C:\\smoke: it is an
     # x86_64 OHOS ELF/Loader/ICD stack launched through Box64 for the B1 gate.
     if [ -f "$BUILD_DIR/guest_vulkan/$guest_arch/manifest.json" ]; then


### PR DESCRIPTION
## 概述

让 x86_64 HarmonyOS PC 模拟器上的 OpenGL（WineD3D/VirGL 软渲染兜底）能够跑通 smoke 且不再让模拟器崩溃。**arm64 真机 virgl 路径零改动**。

## 背景（两个根因）

1. **dlopen ENOENT**：x86_64 上 Wine 原生执行，系统 dlopen 拒绝从应用 el2 数据区加载 guest Mesa 库（`No such file or directory`）；arm64 真机由 Box64 的 dlopen shim 自己读文件，所以没这个问题。
2. **模拟器 express GPU 无法承载宿主 GL**：`eglCreateContext`（空 share）+ `glTexImage2D(NULL)` 纹理分配会让 Emulator.exe 崩溃（多次崩溃均在同一地址 `+0x1B6FCA`，qemu 日志 `real share context is NULL` → `pixels is NULL`）。去掉 surfaceless、去掉 EGL 扩展属性都无法避免，说明该模拟器 GPU 桥跑不了真实 GL 负载。

## 改动（全部 `__x86_64__` / `NATIVE_ARCH=x86_64` 守卫）

- `scripts/assemble.sh`：x86_64 打包时把 guest 专用 Mesa 库（libEGL/libGLESv2/libgallium/libdrm + dri 驱动）复制进 `entry/libs/x86_64`（部署到 el1，系统允许 dlopen）。
- `entry/src/main/cpp/wine_child.cpp`：x86_64 的 `LD_LIBRARY_PATH` 增加 el1 bundle libs 目录。
- `entry/src/main/cpp/graphics_broker.cpp`：x86_64 下 `WINEHUA_EGL_LIBRARY_PATH`/`LIBGL_DRIVERS_PATH` 指向 el1；guest 改 `GALLIUM_DRIVER=softpipe`（软渲染），不再向 guest 暴露 vtest socket。
- `entry/src/main/cpp/virgl_child.cpp`：x86_64 下 vtest 用默认 EGL display（去掉 `--use-egl-surfaceless`/`--venus`），`EGL_PLATFORM=default`。
- `thirdparty/virglrenderer`（子模块 `feature/emulator-x86_64-egl-compat` @ `06ae1f3`）：x86_64 建 EGL 上下文用与 app 合成器一致的极简属性。

## 验证

- `make NATIVE_ARCH=x86_64` 全量构建通过，HAP 签名安装成功。
- 模拟器上 `opengl` smoke 套件：`opengl-x64` / `opengl-x86` 均 PASS（固定帧 rgba-quadrants 自检，~60fps，569 帧），模拟器连续多轮稳定不崩。
- 真机 arm64：未改动任何 arm64 路径（守卫隔离），virgl（surfaceless+GLES+Venus）保持原样。

## 说明

- DXVK/D3D11（Venus/Vulkan）暂未纳入本 PR：模拟器 GPU 桥同样无法承载宿主 Vulkan，真机不受影响。
- `sign/`（本地签名材料）与根 `build-profile.json5` 已加入 .gitignore，不会入库。