### PR TITLE
fix(audio): 来电打断后恢复发声 — RESUME 时重启 AudioRenderer

### DIFF
--- a/entry/src/main/cpp/audio_broker.cpp
+++ b/entry/src/main/cpp/audio_broker.cpp
@@ -386,6 +386,10 @@ bool AudioBroker::EnsureRendererLocked()
         result = OH_AudioStreamBuilder_SetFrameSizeInCallback(builder, kAudioTargetCallbackFrames);
     if (result == AUDIOSTREAM_SUCCESS)
         result = OH_AudioStreamBuilder_SetRendererWriteDataCallback(builder, OnWriteData, this);
+    // 注册打断回调：来电/通话等高优先级音频会打断 GAME 流，挂断后系统发送
+    // RESUME，必须在此回调里显式重新 Start 渲染流，否则音频永久无声。
+    if (result == AUDIOSTREAM_SUCCESS)
+        result = OH_AudioStreamBuilder_SetRendererInterruptCallback(builder, OnInterrupt, this);
 
     if (result != AUDIOSTREAM_SUCCESS)
     {
@@ -630,6 +634,34 @@ void AudioBroker::OnReadData(OH_AudioCapturer* capturer,
     if (!frames) return;
 
     broker->DistributeCaptureFramesS16(snapshot, static_cast<const int16_t*>(audioData), frames);
+}
+
+void AudioBroker::OnInterrupt(OH_AudioRenderer* renderer,
+                              void* userData,
+                              OH_AudioInterrupt_ForceType type,
+                              OH_AudioInterrupt_Hint hint)
+{
+    auto* broker = static_cast<AudioBroker*>(userData);
+
+    (void)renderer;
+    OH_LOG_INFO(LOG_APP, "[AudioBroker] renderer interrupt hint=%{public}d force=%{public}d",
+                static_cast<int>(hint), static_cast<int>(type));
+    if (!broker) return;
+
+    // 来电/通话等高优先级音频以 FORCE 方式打断 GAME 渲染流，系统会把流暂停；
+    // 挂断后系统发送 RESUME，若此时不显式重新 Start，渲染流将停在暂停态，
+    // Wine 内所有音频永久无声。RESUME 时重新启动即可恢复发声。
+    if (hint == AUDIOSTREAM_INTERRUPT_HINT_RESUME)
+    {
+        std::lock_guard<std::mutex> lock(broker->mutex_);
+        if (broker->renderer_)
+        {
+            OH_AudioRenderer_Start(broker->renderer_);
+            OH_LOG_INFO(LOG_APP, "[AudioBroker] renderer resumed after interrupt");
+        }
+    }
+    // PAUSE/STOP/DUCK/UNDUCK/MUTE/UNMUTE：系统已代为处理（暂停/停止/音量），
+    // 应用侧无需额外动作；恢复统一由 RESUME 驱动。
 }
 
 } // namespace winehua

--- a/entry/src/main/cpp/audio_broker.h
+++ b/entry/src/main/cpp/audio_broker.h
@@ -70,6 +70,10 @@ private:
                            void* userData,
                            void* audioData,
                            int32_t audioDataSize);
+    static void OnInterrupt(OH_AudioRenderer* renderer,
+                            void* userData,
+                            OH_AudioInterrupt_ForceType type,
+                            OH_AudioInterrupt_Hint hint);
 
     mutable std::mutex mutex_;
     bool running_ = false;


### PR DESCRIPTION
## 问题

Wine 内音频在来电/通话时被打断，挂断后**永久无声**。

根因：`entry/src/main/cpp/audio_broker.cpp` 创建系统 `AudioRenderer`（`AUDIOSTREAM_USAGE_GAME`）时只注册了写数据回调，**没有注册打断回调**。来电时系统以 FORCE 方式打断 GAME 渲染流并暂停；挂断后系统发送 RESUME，但应用无回调处理 → 渲染流停在暂停态 → 音频无法恢复。

## 修复

在 `EnsureRendererLocked()` 中注册 `OH_AudioStreamBuilder_SetRendererInterruptCallback`（官方 API，since 20），新增 `AudioBroker::OnInterrupt` 回调：

- 收到 `AUDIOSTREAM_INTERRUPT_HINT_RESUME`（挂断恢复）→ 加锁后 `OH_AudioRenderer_Start()` 显式重启渲染流，恢复发声
- PAUSE/STOP/DUCK 等 hint：系统已代为处理，无需额外动作

## 验证

- 构建通过（native 重编 + assemble + hap），debug HAP 已安装到 ARM 平板
- 运行时：`[AudioBroker] renderer ready rate=48000 ch=2 callbackFrames=960` 正常，打断回调注册无失败
- 真机实测：来电打断后挂断，Wine 内音频恢复正常发声

## 涉及文件

- `entry/src/main/cpp/audio_broker.cpp`（+32）
- `entry/src/main/cpp/audio_broker.h`（+4）