### PR TITLE
feat(gst): 补齐 bad/ugly 插件链 — h264parse/asfdemux/MPEG-TS/MIDI/AIFF

### DIFF
--- a/entry/src/main/cpp/wine_env.cpp
+++ b/entry/src/main/cpp/wine_env.cpp
@@ -190,7 +190,31 @@ void AppendD3dBackendEnv(std::vector<std::string>& env,
             "libGLESv1_CM.so:libGLESv1_CM.so.1:libGL.so:libGL.so.1:"
             "libwayland-client.so:libwayland-client.so.0:libwayland-server.so:"
             "libwayland-server.so.0:libwayland-egl.so:libwayland-egl.so.1:"
-            "libdrm.so:libdrm.so.2:libffi.so:libffi.so.8",
+            "libdrm.so:libdrm.so.2:libffi.so:libffi.so.8:"
+            // GStreamer 链 (winegstreamer): glib + gst core/base + bad/ugly 依赖库
+            "libglib-2.0.so:libglib-2.0.so.0:"
+            "libgobject-2.0.so:libgobject-2.0.so.0:"
+            "libgio-2.0.so:libgio-2.0.so.0:"
+            "libgmodule-2.0.so:libgmodule-2.0.so.0:"
+            "libgstreamer-1.0.so:libgstreamer-1.0.so.0:"
+            "libgstbase-1.0.so:libgstbase-1.0.so.0:"
+            "libgstvideo-1.0.so:libgstvideo-1.0.so.0:"
+            "libgstaudio-1.0.so:libgstaudio-1.0.so.0:"
+            "libgsttag-1.0.so:libgsttag-1.0.so.0:"
+            "libgstpbutils-1.0.so:libgstpbutils-1.0.so.0:"
+            "libgstallocators-1.0.so:libgstallocators-1.0.so.0:"
+            "libgstapp-1.0.so:libgstapp-1.0.so.0:"
+            "libgstcontroller-1.0.so:libgstcontroller-1.0.so.0:"
+            "libgstfft-1.0.so:libgstfft-1.0.so.0:"
+            "libgstnet-1.0.so:libgstnet-1.0.so.0:"
+            "libgstriff-1.0.so:libgstriff-1.0.so.0:"
+            "libgstrtp-1.0.so:libgstrtp-1.0.so.0:"
+            "libgstrtsp-1.0.so:libgstrtsp-1.0.so.0:"
+            "libgstsdp-1.0.so:libgstsdp-1.0.so.0:"
+            // bad/ugly 插件依赖: videoparsersbad 需 codecparsers, mpegtsdemux 需 mpegts
+            "libgstcodecparsers-1.0.so:libgstcodecparsers-1.0.so.0:"
+            "libgstmpegts-1.0.so:libgstmpegts-1.0.so.0:"
+            "libxml2.so:libxml2.so.2:libz.so:libz.so.1",
 #endif
         "VK_DRIVER_FILES=" + guestVulkanIcd,
         "VK_ICD_FILENAMES=" + guestVulkanIcd,

--- a/scripts/assemble.sh
+++ b/scripts/assemble.sh
@@ -85,7 +85,8 @@ assemble_pad() {
                   libgstnet-1.0.so.0 libgstvideo-1.0.so.0 libgstaudio-1.0.so.0 \
                   libgsttag-1.0.so.0 libgstpbutils-1.0.so.0 libgstallocators-1.0.so.0 \
                   libgstapp-1.0.so.0 libgstfft-1.0.so.0 libgstriff-1.0.so.0 \
-                  libgstrtp-1.0.so.0 libgstrtsp-1.0.so.0 libgstsdp-1.0.so.0; do
+                  libgstrtp-1.0.so.0 libgstrtsp-1.0.so.0 libgstsdp-1.0.so.0 \
+                  libgstcodecparsers-1.0.so.0 libgstmpegts-1.0.so.0; do
             _pick_lib_pad "$so" "$so"
         done
         log "    交叉编译依赖 → libs/x86_64/"
@@ -190,7 +191,8 @@ assemble_pad() {
                   libgstnet-1.0.so.0 libgstvideo-1.0.so.0 libgstaudio-1.0.so.0 \
                   libgsttag-1.0.so.0 libgstpbutils-1.0.so.0 libgstallocators-1.0.so.0 \
                   libgstapp-1.0.so.0 libgstfft-1.0.so.0 libgstriff-1.0.so.0 \
-                  libgstrtp-1.0.so.0 libgstrtsp-1.0.so.0 libgstsdp-1.0.so.0; do
+                  libgstrtp-1.0.so.0 libgstrtsp-1.0.so.0 libgstsdp-1.0.so.0 \
+                  libgstcodecparsers-1.0.so.0 libgstmpegts-1.0.so.0; do
             # box64 按 SONAME 解析依赖时可能查找无版本名 (libgstvideo-1.0.so),
             # 与 gnutls 链一致补上无版本软链, 否则 winegstreamer dlopen 报
             # "Error loading shared library libgstvideo-1.0.so: No such file"

--- a/scripts/build_gstreamer.sh
+++ b/scripts/build_gstreamer.sh
@@ -22,6 +22,8 @@ PCRE2_SRC="$ROOT/thirdparty/pcre2"
 # 直接用它, 无需外部 .temp/crossover staging。
 BASE_SRC="$ROOT/thirdparty/gstreamer/subprojects/gst-plugins-base"
 GOOD_SRC="$ROOT/thirdparty/gstreamer/subprojects/gst-plugins-good"
+BAD_SRC="$ROOT/thirdparty/gstreamer/subprojects/gst-plugins-bad"
+UGLY_SRC="$ROOT/thirdparty/gstreamer/subprojects/gst-plugins-ugly"
 LIBAV_SRC="$ROOT/thirdparty/gstreamer/subprojects/gst-libav"
 FFMPEG_SRC="$BUILD_DIR/ffmpeg_src"
 
@@ -255,6 +257,58 @@ if [ ! -d "$GST_LIBDIR/gstreamer-1.0" ] || \
     stage_pcs
 else
     log "gst-plugins-good 已就绪，跳过"
+fi
+
+# ── 5b. gst-plugins-bad (h264parse 等视频解析插件) ──
+# H.264 (AVC) in MP4: qtdemux 输出 video/x-h264(stream-format=avc)，需
+# h264parse 转 byte-stream 后 avdec_h264 (libav) 才能解码。缺它会导致
+# decodebin 协商失败 → caps not fixed → 播放失败。
+# 用 -Dauto_features=disabled + 显式 enabled 只编无外部依赖的插件
+# (h264parse 是 videoparsers 的元素, 插件文件名为 libgstvideoparsersbad.so)。
+if [ -d "$BAD_SRC" ] && \
+   [ ! -f "$GST_LIBDIR/gstreamer-1.0/libgstvideoparsersbad.so" ]; then
+    log "--- 构建 gst-plugins-bad (h264parse 等) ---"
+    build="$BUILD_DIR/gst_bad_build"
+    rm -rf "$build"
+    # CUDA 库 (gst-libs/gst/cuda) 用 C++ 编译, OHOS musl 交叉链接缺 libstdc++
+    # 符号; 无 meson option 可禁用。构建期临时 sed 注释 (幂等, 不污染子模块
+    # 提交; 若子模块工作树被还原, 本 sed 下次构建自动重新应用)。
+    sed -i "s/^subdir('cuda')/# subdir('cuda') # disabled: musl C++ link/" \
+        "$BAD_SRC/gst-libs/gst/meson.build"
+    meson setup "$build" "$BAD_SRC" --cross-file "$(gen_cross_file)" \
+        --prefix="$GST_PREFIX" -Dlibdir=lib/x86_64-linux-ohos --wrap-mode=nofallback \
+        -Dc_args="--target=$TARGET --sysroot=$SYSROOT -I$SYSROOT_EXT_INC -D__MUSL__" \
+        -Dauto_features=disabled -Dgpl=disabled -Dexamples=disabled -Dtests=disabled \
+        -Dvideoparsers=enabled -Dasfmux=enabled \
+        -Dmpegdemux=enabled -Dmpegtsdemux=enabled -Dmidi=enabled -Daiff=enabled
+    meson compile -C "$build" -j "$JOBS"
+    DESTDIR=/ meson install -C "$build"
+    stage_pcs
+    log "gst-plugins-bad 构建完成 (h264parse 等)"
+else
+    log "gst-plugins-bad 已就绪或不可用，跳过"
+fi
+
+# ── 5c. gst-plugins-ugly (asfdemux: WMV/ASF 播放) ──
+# 吉里吉里等游戏的 MV 常为 WMV (ASF 容器)。ASF demuxer (asfdemux) 在
+# gst-plugins-ugly (rank=SECONDARY, decodebin 自动选用), 不在 bad。
+# bad 的 asfparse (rank=NONE) 只做 parse 不解 ES, decodebin 不会用它。
+if [ -d "$UGLY_SRC" ] && \
+   [ ! -f "$GST_LIBDIR/gstreamer-1.0/libgstasf.so" ]; then
+    log "--- 构建 gst-plugins-ugly (asfdemux) ---"
+    build="$BUILD_DIR/gst_ugly_build"
+    rm -rf "$build"
+    meson setup "$build" "$UGLY_SRC" --cross-file "$(gen_cross_file)" \
+        --prefix="$GST_PREFIX" -Dlibdir=lib/x86_64-linux-ohos --wrap-mode=nofallback \
+        -Dc_args="--target=$TARGET --sysroot=$SYSROOT -I$SYSROOT_EXT_INC -D__MUSL__" \
+        -Dauto_features=disabled -Dgpl=disabled -Dnls=disabled -Dtests=disabled -Ddoc=disabled \
+        -Dasfdemux=enabled
+    meson compile -C "$build" -j "$JOBS"
+    DESTDIR=/ meson install -C "$build"
+    stage_pcs
+    log "gst-plugins-ugly 构建完成 (asfdemux)"
+else
+    log "gst-plugins-ugly 已就绪或不可用，跳过"
 fi
 
 # ── 6. FFmpeg + gst-libav (通用解码: H.264/VP9/AAC 等) ──


### PR DESCRIPTION
## 背景

上游 `b447764` 已提供 GStreamer 基础链（core + gst-plugins-base + good demuxer + FFmpeg/gst-libav），但缺少 bad/ugly 插件。实测 WA2 等吉里吉里游戏的 WMV/ASF 视频黑屏，decodebin 报 no suitable plugins found——因为 ASF demuxer（asfdemux）在 gst-plugins-ugly，且 H.264 需要 h264parse（在 bad 的 videoparsers）。

## 改动

### scripts/build_gstreamer.sh
- 新增 gst-plugins-bad 段：videoparsers(h264parse)/asfmux/mpegdemux(MPEG-PS)/mpegtsdemux(MPEG-TS)/midi/aiff
- 构建期 sed 禁用 cuda 库（musl 交叉 C++ 链接缺 libstdc++ 符号，meson 无 cuda option）
- 新增 gst-plugins-ugly 段：asfdemux（libgstasf.so，WMV/ASF 必需，rank=SECONDARY）
- bad 段跳过判断以 libgstvideoparsersbad.so 为准

### scripts/assemble.sh
- GStreamer 库列表补 libgstcodecparsers-1.0.so.0 / libgstmpegts-1.0.so.0

### entry/src/main/cpp/wine_env.cpp
- BOX64_EMULATED_LIBS 补 glib/gst 链 + codecparsers/mpegts/xml2/z（否则 box64 dlopen bad/ugly 插件失败）

## 验证
- 设备实机：WA2 开始画面动画（WMV3 1280x720）可正常播放（修复前黑屏）
- decodebin 确认 asfparse→avdec_wmv3/avdec_wmav2 解码链建立
- 插件 73→77（新增 mpegpsdemux/mpegtsdemux/midi/aiff）