### PR TITLE
fix(arm64): el1 Vulkan ICD path and WOW64 vkMapMemory for 32-bit DXVK Heaven

### DIFF
--- a/entry/src/main/cpp/wine_child.cpp
+++ b/entry/src/main/cpp/wine_child.cpp
@@ -88,23 +88,53 @@ static const char *basename_of_path(const char *path)
     return slash ? slash + 1 : path;
 }
 
+static void normalize_basename(const char *path, char *out, size_t out_size)
+{
+    const char *base = basename_of_path(path);
+    size_t j = 0;
+
+    if (!base || !out || !out_size) return;
+    for (size_t i = 0; base[i] && j < out_size - 1; ++i)
+    {
+        char c = base[i];
+        /* Match executable stems rather than their filesystem spelling.  The
+           desktop smoke is named winehua_audio_smoke.exe, so keeping '_'
+           makes the audio diagnostic probe miss its own profile. */
+        if (c == ' ' || c == '\t' || c == '_' || c == '-') continue;
+        if (c >= 'A' && c <= 'Z') c = c - 'A' + 'a';
+        out[j++] = c;
+    }
+    out[j] = '\0';
+}
+
 static bool is_audio_test_exe(int argc, char *argv[])
 {
-    const char *base;
+    char norm[128];
 
-    if (argc <= 0 || !argv[0]) return false;
-    base = basename_of_path(argv[0]);
-    return !strcasecmp(base, "winehua_audio_test.exe") ||
-           !strcasecmp(base, "winehua_audio_test32.exe");
+    /* argv[0] 是 wine 加载器, 实际程序从 argv[1] 开始。
+       保留 audio_test 兼容性，并匹配当前打包并由 SmokeRunner 启动的
+       winehua_audio_smoke.exe；模糊匹配容忍空格、下划线与连字符变体。 */
+    for (int i = 1; i < argc; ++i)
+    {
+        if (!argv[i]) continue;
+        normalize_basename(argv[i], norm, sizeof(norm));
+        if (strstr(norm, "audiotest") != NULL ||
+            strstr(norm, "audiosmoke") != NULL) return true;
+    }
+    return false;
 }
 
 static bool is_sdl_audio_test_exe(int argc, char *argv[])
 {
-    const char *base;
+    char norm[128];
 
-    if (argc <= 0 || !argv[0]) return false;
-    base = basename_of_path(argv[0]);
-    return !strcasecmp(base, "mj_x86.exe") || !strcasecmp(base, "mj_x86d.exe");
+    for (int i = 1; i < argc; ++i)
+    {
+        if (!argv[i]) continue;
+        normalize_basename(argv[i], norm, sizeof(norm));
+        if (strstr(norm, "mjx86") != NULL) return true;
+    }
+    return false;
 }
 
 static bool program_is(const char *program, const char *name)
@@ -312,7 +342,8 @@ static void setup_wine_env(const char* binDir, const char* homeDir, const char *
 #if defined(__aarch64__) && defined(WINEHUA_WINE_ARCH_IS_X86_64)
         // 方案②: box64 转译, el1 arm64 原生库不走 wine PE 搜索
 #else
-        dllPath += ":/data/storage/el1/bundle/libs/" + std::string(native_lib_dir);
+        // 方案①③: unixlib + HAP native libs, so mmdevapi can load wineohos.so
+        dllPath += std::string(":") + libDir + ":/data/storage/el1/bundle/libs/" + native_lib_dir;
 #endif
         setenv("WINEDLLPATH", dllPath.c_str(), 1);
     }
@@ -356,6 +387,97 @@ static void apply_entry_param_env_overrides(const std::vector<std::string>& envO
             OH_LOG_INFO(LOG_APP, "[WineChild] env override %{public}s=%{public}s",
                         key.c_str(), value.c_str());
     }
+}
+
+#ifdef __aarch64__
+static constexpr const char kChildNativeLibDir[] = "arm64";
+#else
+static constexpr const char kChildNativeLibDir[] = "x86_64";
+#endif
+
+static bool path_has_component(const std::string& path, const std::string& dir)
+{
+    if (dir.empty() || path.empty()) return false;
+    size_t start = 0;
+    while (start <= path.size())
+    {
+        size_t end = path.find(':', start);
+        if (end == std::string::npos) end = path.size();
+        if (path.compare(start, end - start, dir) == 0) return true;
+        if (end == path.size()) break;
+        start = end + 1;
+    }
+    return false;
+}
+
+static void append_path_component(std::string& path, const std::string& dir)
+{
+    if (dir.empty() || path_has_component(path, dir)) return;
+    if (!path.empty()) path += ':';
+    path += dir;
+}
+
+static void replace_all(std::string& haystack, const char* from, const char* to)
+{
+    if (!from || !from[0] || !to) return;
+    const size_t fromLen = strlen(from);
+    const size_t toLen = strlen(to);
+    size_t pos = 0;
+    while ((pos = haystack.find(from, pos)) != std::string::npos)
+    {
+        haystack.replace(pos, fromLen, to);
+        pos += toLen;
+    }
+}
+
+/* Parent __env may overlay WINEDLLPATH with DXVK PE dirs and drop the HAP
+ * native-lib directory where wineohos.so is packaged. ntdll redirects dll_dir
+ * to WINEUNIXDIR (wine/bin), so unixlib search must still include bundle libs. */
+static void reassert_arch_wine_runtime_env(const char* binDir)
+{
+    if (!binDir || !binDir[0]) return;
+
+    const std::string unixDir = std::string(binDir) + "/" WINE_UNIX_SUBDIR;
+    const std::string peDir = std::string(binDir) + "/" WINE_PE_SUBDIR;
+    const std::string i386Dir = std::string(binDir) + "/i386-windows";
+    const std::string bundleDir = std::string("/data/storage/el1/bundle/libs/") + kChildNativeLibDir;
+
+    setenv("WINEBINDIR", binDir, 1);
+    setenv("WINEUNIXDIR", binDir, 1);
+    setenv("WINEDLLDIR", unixDir.c_str(), 1);
+
+    const char* dllDir0 = getenv("WINEDLLDIR0");
+    if (!dllDir0 || !dllDir0[0] ||
+        (strstr(dllDir0, "x86_64-windows") != nullptr &&
+         strstr(dllDir0, "/dxvk/") == nullptr))
+        setenv("WINEDLLDIR0", peDir.c_str(), 1);
+
+    const char* existing = getenv("WINEDLLPATH");
+    std::string dllPath = existing ? existing : "";
+#ifdef __aarch64__
+    replace_all(dllPath, "x86_64-windows", WINE_PE_SUBDIR);
+    replace_all(dllPath, "x86_64-unix", WINE_UNIX_SUBDIR);
+#endif
+    append_path_component(dllPath, peDir);
+    append_path_component(dllPath, i386Dir);
+    append_path_component(dllPath, binDir);
+    append_path_component(dllPath, unixDir);
+    append_path_component(dllPath, bundleDir);
+    setenv("WINEDLLPATH", dllPath.c_str(), 1);
+
+    const char* path = getenv("PATH");
+    if (path && strstr(path, "x86_64-windows"))
+    {
+        std::string p = path;
+        replace_all(p, "x86_64-windows", WINE_PE_SUBDIR);
+        setenv("PATH", p.c_str(), 1);
+    }
+
+    OH_LOG_INFO(LOG_APP,
+                "[WineChild] reassert WINEDLLDIR=%{public}s WINEDLLDIR0=%{public}s WINEDLLPATH=%{public}s",
+                unixDir.c_str(),
+                getenv("WINEDLLDIR0") ? getenv("WINEDLLDIR0") : "",
+                dllPath.c_str());
 }
 
 static void log_d3d_environment_summary()
@@ -517,7 +639,23 @@ extern "C" void Main(NativeChildProcess_Args args)
     // Step B: entryParams 中的环境覆盖应用。
     apply_entry_param_env_overrides(envOverrides);
 
-    if (!hostElfMode) log_d3d_environment_summary();
+    if (!hostElfMode) {
+        reassert_arch_wine_runtime_env(binDir);
+        /* Parent serializes WINEDEBUG=-all,+opengl,... which clobbers the
+         * audio diagnostic profile selected in setup_wine_env(). Restore it
+         * so mmdevapi/wineohos traces actually appear for audio tests. */
+        if (is_audio_test_exe(argc, argv) || is_sdl_audio_test_exe(argc, argv))
+        {
+            const char *profile = select_winedebug_profile(argc, argv);
+            setenv("WINEDEBUG", profile, 1);
+            OH_LOG_INFO(LOG_APP, "[WineChild] restored audio WINEDEBUG=%{public}s", profile);
+        }
+        log_d3d_environment_summary();
+        OH_LOG_INFO(LOG_APP,
+                    "[WineChild] final WINEDLLDIR=%{public}s WINEDEBUG=%{public}s",
+                    getenv("WINEDLLDIR") ? getenv("WINEDLLDIR") : "",
+                    getenv("WINEDEBUG") ? getenv("WINEDEBUG") : "");
+    }
 
     // 覆盖 per-process fd 变量 (__env__ 中的是父进程 fd 号, 本进程无效)
     if (wsSockFd >= 0) {
@@ -527,6 +665,18 @@ extern "C" void Main(NativeChildProcess_Args args)
         OH_LOG_INFO(LOG_APP, "[WineChild] WINESERVERSOCKET=%{public}d (own fd)", wsSockFd);
     }
     if (audioFd >= 0) {
+        /* 保护 bootstrap fd: dup 到高位, 避免 wine ntdll 启动时复用低 fd */
+        int saved = fcntl(audioFd, F_DUPFD, 512);
+        if (saved >= 0)
+        {
+            OH_LOG_INFO(LOG_APP, "[WineChild] audio bootstrap fd dup %{public}d -> %{public}d (guard high)",
+                        audioFd, saved);
+            audioFd = saved;
+        }
+        else
+        {
+            OH_LOG_WARN(LOG_APP, "[WineChild] audio bootstrap fd dup failed errno=%{public}d", errno);
+        }
         char buf[32];
         snprintf(buf, sizeof(buf), "%d", audioFd);
         setenv("WINE_OHOS_AUDIO_ENABLE", "1", 1);

--- a/entry/src/main/cpp/wine_child.cpp
+++ b/entry/src/main/cpp/wine_child.cpp
@@ -307,9 +307,14 @@ static void setup_wine_env(const char* binDir, const char* homeDir, const char *
     setenv("BOX64_LD_LIBRARY_PATH", libDir.c_str(), 1);
     SetBox64PerfEnv();
     setenv("USE_LIBBOX64", "1", 1);  // 供 wine process.c 识别 in-process box64
+#elif defined(__aarch64__)
+    // 方案③ arm64 原生 wine: Harmony musl 会因 el2 目录拒绝整条
+    // LD_LIBRARY_PATH 或跳过后续 el1 项。guest GL/Vulkan 已复制到 HAP
+    // native libs, 只保留 el1 供系统 dlopen。
+    setenv("LD_LIBRARY_PATH",
+           (std::string("/data/storage/el1/bundle/libs/") + native_lib_dir).c_str(), 1);
 #else
-    // 方案①③ (Wine 与设备同架构): 系统 linker 直接加载, Wine .so 打包在
-    // bundle libs (el1, 系统 dlopen 允许), 依赖也从该目录解析
+    // 方案① x86_64 原生 wine
     setenv("LD_LIBRARY_PATH",
            (libDir + ":/data/storage/el1/bundle/libs/" + native_lib_dir).c_str(), 1);
 #endif
@@ -465,6 +470,13 @@ static void reassert_arch_wine_runtime_env(const char* binDir)
     append_path_component(dllPath, bundleDir);
     setenv("WINEDLLPATH", dllPath.c_str(), 1);
 
+#if defined(__aarch64__) && !defined(WINEHUA_WINE_ARCH_IS_X86_64)
+    /* Parent __env still serializes el2 guest_gfx/wine/bin first. That
+     * poisons musl ICD/loader scans on 方案③; force the el1-only path.
+     * 方案② keeps the box64 host LD_LIBRARY_PATH from setup_wine_env. */
+    setenv("LD_LIBRARY_PATH", bundleDir.c_str(), 1);
+#endif
+
     const char* path = getenv("PATH");
     if (path && strstr(path, "x86_64-windows"))
     {
@@ -474,10 +486,12 @@ static void reassert_arch_wine_runtime_env(const char* binDir)
     }
 
     OH_LOG_INFO(LOG_APP,
-                "[WineChild] reassert WINEDLLDIR=%{public}s WINEDLLDIR0=%{public}s WINEDLLPATH=%{public}s",
+                "[WineChild] reassert WINEDLLDIR=%{public}s WINEDLLDIR0=%{public}s "
+                "WINEDLLPATH=%{public}s LD_LIBRARY_PATH=%{public}s",
                 unixDir.c_str(),
                 getenv("WINEDLLDIR0") ? getenv("WINEDLLDIR0") : "",
-                dllPath.c_str());
+                dllPath.c_str(),
+                getenv("LD_LIBRARY_PATH") ? getenv("LD_LIBRARY_PATH") : "");
 }
 
 static void log_d3d_environment_summary()
@@ -528,6 +542,35 @@ static void log_d3d_environment_summary()
                 mesaLogLevel ? mesaLogLevel : "",
                 batchMappedFlush ? batchMappedFlush : "",
                 rgba8SnormRt ? rgba8SnormRt : "");
+    const char* ldPath = getenv("LD_LIBRARY_PATH");
+    const char* icd = getenv("VK_ICD_FILENAMES");
+    const char* drivers = getenv("VK_DRIVER_FILES");
+    OH_LOG_INFO(LOG_APP,
+                "[WineChild] vulkan scan LD_LIBRARY_PATH=%{public}s "
+                "VK_ICD_FILENAMES=%{public}s VK_DRIVER_FILES=%{public}s",
+                ldPath ? ldPath : "",
+                icd ? icd : "",
+                drivers ? drivers : "");
+#ifdef __aarch64__
+    void* vulkan = dlopen("libvulkan.so.1", RTLD_NOW | RTLD_LOCAL);
+    if (!vulkan)
+    {
+        const char* err = dlerror();
+        OH_LOG_ERROR(LOG_APP, "[WineChild] dlopen libvulkan.so.1 failed: %{public}s",
+                     err ? err : "(null)");
+    }
+    else
+    {
+        Dl_info info;
+        void* sym = dlsym(vulkan, "vkCreateInstance");
+        if (sym && dladdr(sym, &info) && info.dli_fname)
+            OH_LOG_INFO(LOG_APP, "[WineChild] libvulkan.so.1 loaded from %{public}s",
+                        info.dli_fname);
+        else
+            OH_LOG_INFO(LOG_APP, "[WineChild] libvulkan.so.1 loaded, path unknown");
+        dlclose(vulkan);
+    }
+#endif
 }
 
 static void prepare_host_elf_environment(const char *homeDir)

--- a/entry/src/main/cpp/wine_env.cpp
+++ b/entry/src/main/cpp/wine_env.cpp
@@ -19,6 +19,30 @@
 #define LOG_TAG "WL_NAPI"
 #include <hilog/log.h>
 
+#ifdef __aarch64__
+static constexpr const char kNativeLibDirName[] = "arm64";
+#else
+static constexpr const char kNativeLibDirName[] = "x86_64";
+#endif
+
+static std::string BundleNativeLibsDir()
+{
+    return std::string("/data/storage/el1/bundle/libs/") + kNativeLibDirName;
+}
+
+static std::string UnixlibSearchPath(const std::string& binDir)
+{
+    return binDir + "/" WINE_UNIX_SUBDIR ":" + BundleNativeLibsDir();
+}
+
+static std::string BuiltinWineDllPath(const std::string& binDir)
+{
+    return binDir + "/" WINE_PE_SUBDIR ":" +
+           binDir + "/i386-windows:" +
+           binDir + ":" +
+           UnixlibSearchPath(binDir);
+}
+
 int CreateAudioBootstrapFd(const std::string& runtimeDir) {
     if (!winehua::AudioBroker::GetInstance().EnsureStarted(runtimeDir)) {
         OH_LOG_ERROR(LOG_APP, "[AudioBroker] failed to start for runtimeDir=%{public}s", runtimeDir.c_str());
@@ -41,6 +65,7 @@ std::vector<std::string> BuildWineEnv(const std::string& sockDir,
                                       const std::string& homeDir,
                                       const std::string& prefixDir,
                                       const std::string& wineLang) {
+    (void)libPath;
     std::string shareDir = binDir + "/../share";
     LogWineScheme("BuildWineEnv");
     std::string xkbDir = shareDir + "/X11/xkb";
@@ -70,8 +95,8 @@ std::vector<std::string> BuildWineEnv(const std::string& sockDir,
 #if defined(__aarch64__) && defined(WINEHUA_WINE_ARCH_IS_X86_64)
     // 方案②: box64 转译, el1 arm64 原生库不走 wine PE/unixlib 搜索 (与 wine_child.cpp 一致)
 #else
-    // bundled libs 加入 WINEDLLPATH, load_unixlib_by_name() 从此搜索 .so
-    dllPath += std::string(":/data/storage/el1/bundle/libs/") + native_lib_dir;
+    // unixlib + bundled libs so load_unixlib_by_name() can find wineohos.so
+    dllPath += std::string(":") + UnixlibSearchPath(binDir);
 #endif
 
     // ==== Layer 0: 硬基线 (路径、locale、Wayland socket) ====
@@ -82,6 +107,8 @@ std::vector<std::string> BuildWineEnv(const std::string& sockDir,
         "HOME=" + homeDir,
         "WINEPREFIX=" + (prefixDir.empty() ? std::string(WINE_PREFIX) : prefixDir),
         "WINEDATADIR=" + shareDir + "/wine",
+        "WINEBINDIR=" + binDir,
+        "WINEUNIXDIR=" + binDir,
         "WINEDLLDIR=" + binDir + "/" WINE_UNIX_SUBDIR,
         "WINEDLLDIR0=" + binDir + "/" WINE_PE_SUBDIR,
         "WINEDLLDIR1=" + binDir + "/i386-windows",
@@ -194,8 +221,13 @@ void AppendD3dBackendEnv(std::vector<std::string>& env,
         binDir + "/" WINE_UNIX_SUBDIR ":" +
         std::string(WINE_RUNTIME_ROOT) + "/lib/x86_64";
 #endif
+    /* DXVK overlays must stay first so d3d11/dxgi resolve to the managed PE
+     * copies. Keep unixlib search dirs after that: wineohos.so is packaged in
+     * HAP native libs, not wine/bin/aarch64-unix, and ntdll redirects dll_dir
+     * to WINEUNIXDIR (wine/bin). Without these tails, mmdevapi cannot load
+     * wineohos.drv's unixlib and GetDefaultAudioEndpoint returns E_NOTFOUND. */
     const std::string wineDllPath = overlay64 + ":" + overlay86 + ":" +
-        binDir + "/" WINE_PE_SUBDIR ":" + binDir + "/i386-windows:" + binDir;
+        BuiltinWineDllPath(binDir);
 
     const std::vector<std::string> managed = {
         "WINEHUA_D3D_BACKEND=" + d3dBackend,
@@ -272,6 +304,7 @@ void AppendD3dBackendEnv(std::vector<std::string>& env,
         "WINEDLLDIR1=" + overlay86,
     };
     for (const std::string& line : managed) UpsertEnvLine(env, line);
+    OH_LOG_INFO(LOG_APP, "[WineEnv] DXVK WINEDLLPATH=%{public}s", wineDllPath.c_str());
 #ifdef __aarch64__
     // arm64: 若 aarch64 venus ICD 已打包 (guest_vulkan bundle 存在 icd json) 则 DXVK
     // 走 venus→vtest 硬件加速; 否则回退宿主 Vulkan (旧 HAP / venus 未构建)。

--- a/entry/src/main/cpp/wine_env.cpp
+++ b/entry/src/main/cpp/wine_env.cpp
@@ -87,9 +87,21 @@ std::vector<std::string> BuildWineEnv(const std::string& sockDir,
         guestReceiverLibDir = graphicsState.guestReceiverRuntimeDir + "/lib";
         if (access(guestReceiverLibDir.c_str(), F_OK) == 0) {
             libPathBase = guestReceiverLibDir + ":" + libPathBase;
+        } else {
+            guestReceiverLibDir.clear();
         }
     }
+#if defined(__aarch64__) && !defined(WINEHUA_WINE_ARCH_IS_X86_64)
+    /* Harmony musl may reject the entire LD_LIBRARY_PATH when it contains
+     * el2 data-area dirs (check ns accessible failed). el2 libvulkan.so.1
+     * can also open() then fail mmap, which skips later el1 entries.
+     * Guest GL/Vulkan .so are already copied to HAP native libs; keep
+     * native dlopen on that el1 directory only. WINEDLLPATH still lists
+     * el2 Wine PE/unix dirs because ntdll opens those by full path. */
+    const std::string runtimeLibPath = BundleNativeLibsDir();
+#else
     std::string runtimeLibPath = libPathBase + ":/data/storage/el1/bundle/libs/" + native_lib_dir;
+#endif
 
     std::string dllPath = binDir + "/" WINE_PE_SUBDIR ":" + binDir + "/i386-windows:" + binDir;
 #if defined(__aarch64__) && defined(WINEHUA_WINE_ARCH_IS_X86_64)

--- a/entry/src/main/cpp/wine_exe.cpp
+++ b/entry/src/main/cpp/wine_exe.cpp
@@ -231,7 +231,7 @@ static int SpawnWineProgramImpl(const ProgramOptions& options)
         : (gBrokerHomeDir.empty() ? "/storage/Users/currentUser/Download" : gBrokerHomeDir);
     const std::string sockDir = prefixDir;
     const std::string sockName = "wine-wayland";
-    const std::string libPath = binDir + ":" + binDir + "/x86_64-unix";
+    const std::string libPath = binDir + ":" + binDir + "/" WINE_UNIX_SUBDIR;
     const std::string exePath = NativePathToWindows(options.windowsExePath, prefixDir);
 
     winehua::GraphicsBroker::GetInstance().SetWineRuntimeBinaryDir(binDir);

--- a/entry/src/main/cpp/wine_launch.cpp
+++ b/entry/src/main/cpp/wine_launch.cpp
@@ -306,7 +306,7 @@ static void AppendStableDesktopDxvkEnv(std::vector<std::string>& env,
     /* Product sessions retain warnings and errors without formatting DXVK's
      * informational startup stream. Smoke and explicit diagnostics override
      * this through runWineProgram's per-process environment. */
-    UpsertEnvLine(env, "DXVK_LOG_LEVEL=warn");
+    UpsertEnvLine(env, "DXVK_LOG_LEVEL=info");
     UpsertEnvLine(env, "DXVK_LOG_PATH=C:\\windows\\temp");
     UpsertEnvLine(env, "WINEHUA_PERF_PROFILE=" + selectedProfile);
     UpsertEnvLine(env, "DXVK_WINEHUA_PRECISE_SHADOW=1");

--- a/entry/src/main/ets/entryability/EntryAbility.ets
+++ b/entry/src/main/ets/entryability/EntryAbility.ets
@@ -30,7 +30,17 @@ export default class EntryAbility extends UIAbility {
     const requestedD3d = explicitD3d ? value('winehua.d3d_backend', 'wined3d') :
       (mode === '' ? persistedD3d : 'wined3d');
     const d3dBackend = requestedD3d === 'dxvk_legacy' ? 'dxvk_legacy' : 'wined3d';
-    const gamePath = value('winehua.game_path', '');
+    const rawGamePath = value('winehua.game_path', '');
+    let gamePath = rawGamePath;
+    if (rawGamePath.indexOf('%') >= 0) {
+      try {
+        gamePath = decodeURIComponent(rawGamePath);
+      } catch (_err) {
+        gamePath = rawGamePath;
+      }
+    }
+    hilog.info(DOMAIN, 'GameTest', 'want game_path raw=%{public}s decoded=%{public}s',
+      rawGamePath, gamePath);
     const requestedGameArgCount = Number(value('winehua.game_argc', '0'));
     const gameArgCount = Math.max(0, Math.min(64, Math.floor(requestedGameArgCount)));
     const gameArguments: string[] = [];

--- a/entry/src/main/ets/pages/Index.ets
+++ b/entry/src/main/ets/pages/Index.ets
@@ -110,9 +110,9 @@ struct Index {
   private d3dLaunchEnvironment(): Record<string, string> {
     if (this.d3dBackend !== 'dxvk_legacy') return {};
     const environment: Record<string, string> = {
-      'DXVK_LOG_LEVEL': 'warn',
-      'DXVK_LOG_PATH': 'C:\\smoke\\results\\desktop-dxvk',
-      'WINEDEBUG': '-all',
+      'DXVK_LOG_LEVEL': 'info',
+      'DXVK_LOG_PATH': 'C:\\windows\\temp',
+      'WINEDEBUG': '-all,+err,+vulkan,+winediag',
       /* Venus uses a shared-memory command ring between the x86_64 guest and
        * the ARM64 renderer.  Box64's aggressive weak-barrier mode can violate
        * the x86 ordering expected by the ring and eventually corrupt a random

--- a/entry/src/main/ets/service/WineEnvService.ets
+++ b/entry/src/main/ets/service/WineEnvService.ets
@@ -18,7 +18,8 @@ export const SOCK = '/data/storage/el2/base/files/.wine/wine-wayland';
 // Wine 运行时从 rawfile 解压到 files/
 const WINE_ROOT = `${FILES_BASE}/wine`;
 export const WINE_BIN = `${WINE_ROOT}/bin`;
-export const WINE_LIB = `${WINE_BIN}/x86_64-unix`;
+export const WINE_UNIX_SUBDIR = 'aarch64-unix';
+export const WINE_LIB = `${WINE_BIN}/${WINE_UNIX_SUBDIR}`;
 const BIN_DIR = WINE_BIN;
 const BOX64 = `${WINE_BIN}/box64`;
 

--- a/entry/src/main/ets/service/WineEnvService.ets
+++ b/entry/src/main/ets/service/WineEnvService.ets
@@ -854,7 +854,7 @@ export class WineEnvService {
       this.setInitStatus('解压数据...', !this.bgStart);
       hilog.warn(DOMAIN, 'wine', 'auto-init: extracting wine data (missing)...');
       await this.extractWineData();
-    } else if (this.upgradeNeedsAttention() && !this.isAutomation()) {
+    } else if (this.upgradeNeedsAttention() && !this.automationMode && !this.gameTestMode) {
       hilog.warn(DOMAIN, 'wine', 'auto-init: runtime outdated, NOT auto-extracting (user-initiated)');
       // 中止初始化: 引擎保持未启动, 弹卡等用户决定 (应用=doReset 引擎静止
       // 无竞态; 稍后=dismiss 记跳过 sha 后补拉起, 同版本不再拦截)。
@@ -869,7 +869,7 @@ export class WineEnvService {
       this.upgradePending = true;
       this.notify();
       return;
-    } else if (this.runtimeNeedsRefresh() && this.isAutomation()) {
+    } else if (this.runtimeNeedsRefresh() && (this.automationMode || this.gameTestMode)) {
       // 自动化/游戏测试模式 (无人值守): 升级不弹卡 — 没有用户可点,
       // 中止会让 smoke/game 等 ready 永久挂起; 保持旧行为自动解压自愈。
       // 注意必须带 isAutomation 条件: 普通模式"已跳过的升级"
@@ -1199,11 +1199,11 @@ export class WineEnvService {
   // perf profile 对应的一组 VN_/VKR_/DXVK_ 开关, 最后叠加 want 携带的显式覆盖项
   private d3dLaunchEnvironment(): Record<string, string> {
     if (this.d3dBackend !== 'dxvk_legacy') return {};
-    ensureDirectory(`${this.driveC}/smoke/results/desktop-dxvk`);
+    ensureDirectory(`${this.driveC}/windows/temp`);
     const environment: Record<string, string> = {
-      'DXVK_LOG_LEVEL': 'warn',
-      'DXVK_LOG_PATH': 'C:\\smoke\\results\\desktop-dxvk',
-      'WINEDEBUG': '-all',
+      'DXVK_LOG_LEVEL': 'info',
+      'DXVK_LOG_PATH': 'C:\\windows\\temp',
+      'WINEDEBUG': '-all,+err,+vulkan,+winediag',
       /* Venus 在 x86_64 guest 与 ARM64 renderer 之间用共享内存命令环。
        * Box64 激进的弱屏障模式可能破坏 ring 期望的 x86 定序, 最终损坏随机
        * Vulkan 命令。该约束只作用于 DXVK/Venus 进程。 */


### PR DESCRIPTION
## Summary
- 方案③（arm64 原生 Wine）把 `LD_LIBRARY_PATH` 收成 el1 `bundle/libs/arm64`，避免 Harmony musl 因 el2 目录整段拒绝 / 跳过 Venus ICD。方案② box64 路径不动。
- `win32u` WOW64 `vkMapMemory`：把 Venus 返回的 64 位 virtgpu 映射别名进 32 位 VA（mremap 一致性探测 → mmap 同 fd → QueueSubmit CPU 副本），32 位 Heaven 可以 `D3D11CreateDevice`。
- 游戏测试模式升级时自动解压 wine-data；`winehua.game_path` 支持 URI 解码；DXVK 日志改到可写的 `C:\windows\temp`。
- 顺带带上 unixlib/`wineohos` 搜索路径，避免 DXVK 覆盖 `WINEDLLPATH` 后桌面音频丢驱动。

## 修改细节
### wine (`thirdparty/wine` → `db8df6a` on `winehua/wine` `feature/arm64`)
32 位 WowBox64 进程里 `vkMapMemory` 得到 `0x7xxxx...`，Wine 原路径依赖 `VK_EXT_map_memory_placed`，Venus/Maleoon 没有，于是 `VK_ERROR_OUT_OF_HOST_MEMORY`。
现在：`NtAllocateVirtualMemory(zero_bits)` 拿到 32 位地址后：
1. `mremap(DONTUNMAP)`，写一字节再从 64 位 host 指针读回，确认真共享页；Harmony 假成功或 MOVE 了 VMA 则还原 host 映射。
2. `mmap MAP_FIXED` 同一 backing fd。
3. CPU 副本，在 `vkQueueSubmit`/`Submit2` 整块拷回。别名路径不要用 `VK_MEMORY_UNMAP_RESERVE_BIT_EXT`。

### 运行时（方案③ only）
- `wine_child.cpp` / `wine_env.cpp`：系统 `dlopen` 只扫 el1；`WINEDLLPATH` 仍含 el2 Wine PE/unix（ntdll 按全路径打开）。
- `WineEnvService.ets`：`gameTestMode` 也自动解压升级数据，否则新 `win32u.so` 只在 HAP libs 里，Wine 仍加载旧 el2 so。
- `EntryAbility.ets`：`winehua.game_path` 含 `%` 时 `decodeURIComponent`（Heaven 路径有空格）。
- DXVK：`DXVK_LOG_PATH=C:\windows\temp`，`DXVK_LOG_LEVEL=info`，`WINEDEBUG=-all,+err,+vulkan,+winediag`。

## 验证
Maleoon 910 上 32 位 Heaven 4.0（WowBox64，640×360 windowed Direct3D11）：Venus instance + `D3D11CreateDevice` 成功，世界加载，窗口 FPS 约 25。已与 origin `feature/arm64` 三方案共存提交 rebase。

## Test plan
- [ ] 方案③：32 位 Heaven `D3D11CreateDevice`；stderr 可见 `WOW64 aliased vkMapMemory` 或 coherent fallback
- [ ] 方案③：x64 cube 仍 PASS
- [ ] 方案② box64+wine：桌面/音频不被 el1-only `LD_LIBRARY_PATH` 打坏
- [ ] 游戏测试模式升级 HAP 后会自动解压 wine-data
