### PR TITLE
feat(input): port native Controller Hub architecture

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -453,6 +453,11 @@ test:
 	    -o $(HOST_TEST_DIR)/toplevel_event_test \
 	    $(ROOT)/host_tests/toplevel_event_test.cpp
 	$(HOST_TEST_DIR)/toplevel_event_test
+	g++ -std=c++17 -Wall -Wextra -I $(ROOT)/entry/src/main/cpp \
+	    -o $(HOST_TEST_DIR)/controller_merge_test \
+	    $(ROOT)/host_tests/controller_merge_test.cpp \
+	    $(ROOT)/entry/src/main/cpp/input/controller/controller_hub.cpp
+	$(HOST_TEST_DIR)/controller_merge_test
 
 
 # ============================================================

--- a/entry/src/main/cpp/CMakeLists.txt
+++ b/entry/src/main/cpp/CMakeLists.txt
@@ -32,6 +32,12 @@ add_library(entry SHARED
     audio/audio_stream.cpp
     graphics/graphics_broker.cpp
     graphics/virgl_host_config.cpp
+    input/game_controller_bridge.cpp
+    input/controller/controller_hub.cpp
+    input/controller/controller_napi.cpp
+    input/controller/controller_runtime.cpp
+    input/controller/gamepad_bridge.cpp
+    input/controller/physical_gamepad.cpp
     bridge/napi_init.cpp
     proc/wine_process.cpp
     wine/wine_env.cpp

--- a/entry/src/main/cpp/bridge/napi_init.cpp
+++ b/entry/src/main/cpp/bridge/napi_init.cpp
@@ -15,6 +15,8 @@
 #include "wine/wine_exe.h"
 #include "phone_adapter/phone_adapter.h"
 #include "input/text_input.h"
+#include "input/game_controller_bridge.h"
+#include "input/controller/controller_napi.h"
 
 #include <unistd.h>
 #include <signal.h>
@@ -1150,6 +1152,26 @@ static napi_value Init(napi_env env, napi_value exports) {
         {"setToplevelVisible", nullptr, SetToplevelVisible, nullptr, nullptr, nullptr, napi_default, nullptr},
         {"getProcessList",   nullptr, GetProcessList,   nullptr, nullptr, nullptr, napi_default, nullptr},
         {"killProcess",     nullptr, KillProcess,     nullptr, nullptr, nullptr, napi_default, nullptr},
+        {"initGameController", nullptr, InitGameController, nullptr, nullptr, nullptr, napi_default, nullptr},
+        {"cleanupGameController", nullptr, CleanupGameController, nullptr, nullptr, nullptr, napi_default, nullptr},
+        {"isGamepadConnected", nullptr, IsGamepadConnected, nullptr, nullptr, nullptr, napi_default, nullptr},
+        {"getGamepadCount", nullptr, GetGamepadCount, nullptr, nullptr, nullptr, napi_default, nullptr},
+        {"setGamepadButtonCallback", nullptr, SetGamepadButtonCallback, nullptr, nullptr, nullptr, napi_default, nullptr},
+        {"setGamepadAxisCallback", nullptr, SetGamepadAxisCallback, nullptr, nullptr, nullptr, napi_default, nullptr},
+        {"setGamepadDeviceCallback", nullptr, SetGamepadDeviceCallback, nullptr, nullptr, nullptr, napi_default, nullptr},
+        {"setGamepadRumbleCallback", nullptr, SetGamepadRumbleCallback, nullptr, nullptr, nullptr, napi_default, nullptr},
+        {"controllerSetEnabled", nullptr, ControllerSetEnabled, nullptr, nullptr, nullptr, napi_default, nullptr},
+        {"controllerSetButton", nullptr, ControllerSetButton, nullptr, nullptr, nullptr, napi_default, nullptr},
+        {"controllerSetAxis", nullptr, ControllerSetAxis, nullptr, nullptr, nullptr, napi_default, nullptr},
+        {"controllerSetHat", nullptr, ControllerSetHat, nullptr, nullptr, nullptr, napi_default, nullptr},
+        {"controllerResetSource", nullptr, ControllerResetSource, nullptr, nullptr, nullptr, napi_default, nullptr},
+        {"controllerGetState", nullptr, ControllerGetState, nullptr, nullptr, nullptr, napi_default, nullptr},
+        {"controllerGetStateText", nullptr, ControllerGetStateText, nullptr, nullptr, nullptr, napi_default, nullptr},
+        {"controllerStartBridge", nullptr, ControllerStartBridge, nullptr, nullptr, nullptr, napi_default, nullptr},
+        {"controllerStopBridge", nullptr, ControllerStopBridge, nullptr, nullptr, nullptr, napi_default, nullptr},
+        {"controllerGetSocketPath", nullptr, ControllerGetSocketPath, nullptr, nullptr, nullptr, napi_default, nullptr},
+        {"controllerSetOutputMode", nullptr, ControllerSetOutputMode, nullptr, nullptr, nullptr, napi_default, nullptr},
+        {"controllerGetOutputMode", nullptr, ControllerGetOutputMode, nullptr, nullptr, nullptr, napi_default, nullptr},
     };
     napi_define_properties(env, exports, sizeof(desc) / sizeof(desc[0]), desc);
 

--- a/entry/src/main/cpp/input/controller/controller_hub.cpp
+++ b/entry/src/main/cpp/input/controller/controller_hub.cpp
@@ -1,0 +1,274 @@
+#include "input/controller/controller_hub.h"
+
+#include <algorithm>
+#include <cmath>
+
+namespace winehua {
+namespace controller {
+
+ControllerHub& ControllerHub::Instance()
+{
+    static ControllerHub hub;
+    return hub;
+}
+
+void ControllerHub::SetEnabled(bool enabled)
+{
+    StateListener cb;
+    LogicalGamepadState snaps[kMaxControllerSlots];
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        enabled_ = enabled;
+        cb = listener_;
+        if (!enabled) {
+            for (uint32_t s = 0; s < kMaxControllerSlots; ++s) {
+                slots_[s] = SlotState{};
+                snaps[s] = slots_[s].logical;
+            }
+        }
+    }
+    if (!enabled && cb) {
+        for (uint32_t s = 0; s < kMaxControllerSlots; ++s) cb(s, snaps[s]);
+    }
+}
+
+bool ControllerHub::IsEnabled() const
+{
+    std::lock_guard<std::mutex> lock(mutex_);
+    return enabled_;
+}
+
+void ControllerHub::SetInnerDeadzone(float inner)
+{
+    std::lock_guard<std::mutex> lock(mutex_);
+    innerDeadzone_ = std::clamp(inner, 0.f, 0.5f);
+}
+
+void ControllerHub::SetStateListener(StateListener listener)
+{
+    std::lock_guard<std::mutex> lock(mutex_);
+    listener_ = std::move(listener);
+}
+
+LogicalGamepadState ControllerHub::GetState(uint32_t slot) const
+{
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (slot >= kMaxControllerSlots) return {};
+    return slots_[slot].logical;
+}
+
+void ControllerHub::SetButton(ControllerSourceId source, uint32_t slot, LogicalButton button, bool pressed)
+{
+    const uint32_t src = static_cast<uint32_t>(source);
+    const uint32_t btn = static_cast<uint32_t>(button);
+    if (src >= kSourceCount || btn >= kButtonCount || slot >= kMaxControllerSlots) return;
+
+    StateListener cb;
+    LogicalGamepadState snap;
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (!enabled_) return;
+        uint32_t& owners = slots_[slot].buttonOwners[btn];
+        const uint32_t bit = 1u << src;
+        if (pressed) owners |= bit;
+        else owners &= ~bit;
+        RecomputeLocked(slot);
+        cb = listener_;
+        snap = slots_[slot].logical;
+    }
+    if (cb) cb(slot, snap);
+}
+
+void ControllerHub::SetAxis(ControllerSourceId source, uint32_t slot, LogicalAxis axis, float value)
+{
+    const uint32_t src = static_cast<uint32_t>(source);
+    const uint32_t ax = static_cast<uint32_t>(axis);
+    if (src >= kSourceCount || ax >= kAxisCount || slot >= kMaxControllerSlots) return;
+
+    StateListener cb;
+    LogicalGamepadState snap;
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (!enabled_) return;
+
+        float v = value;
+        if (axis == LogicalAxis::LT || axis == LogicalAxis::RT) {
+            v = std::clamp(v, 0.f, 1.f);
+            slots_[slot].axisValues[src][ax] = v;
+            slots_[slot].axisActive[src][ax] = v > 0.02f;
+        } else {
+            v = std::clamp(v, -1.f, 1.f);
+            slots_[slot].axisValues[src][ax] = v;
+            const bool isLeft = (axis == LogicalAxis::LX || axis == LogicalAxis::LY);
+            const uint32_t axX = static_cast<uint32_t>(isLeft ? LogicalAxis::LX : LogicalAxis::RX);
+            const uint32_t axY = static_cast<uint32_t>(isLeft ? LogicalAxis::LY : LogicalAxis::RY);
+            const float dx = slots_[slot].axisValues[src][axX];
+            const float dy = slots_[slot].axisValues[src][axY];
+            const float mag = std::sqrt(dx * dx + dy * dy);
+            const bool active = mag > innerDeadzone_;
+            slots_[slot].axisActive[src][axX] = active;
+            slots_[slot].axisActive[src][axY] = active;
+            if (active) {
+                slots_[slot].axisOwner[axX] = source;
+                slots_[slot].axisOwner[axY] = source;
+            } else if (slots_[slot].axisOwner[axX] == source) {
+                slots_[slot].axisOwner[axX] = ControllerSourceId::Touch;
+                slots_[slot].axisOwner[axY] = ControllerSourceId::Touch;
+                for (uint32_t s = 0; s < kSourceCount; ++s) {
+                    if (slots_[slot].axisActive[s][axX] || slots_[slot].axisActive[s][axY]) {
+                        slots_[slot].axisOwner[axX] = static_cast<ControllerSourceId>(s);
+                        slots_[slot].axisOwner[axY] = static_cast<ControllerSourceId>(s);
+                        break;
+                    }
+                }
+            }
+        }
+
+        RecomputeLocked(slot);
+        cb = listener_;
+        snap = slots_[slot].logical;
+    }
+    if (cb) cb(slot, snap);
+}
+
+void ControllerHub::SetHat(ControllerSourceId source, uint32_t slot, int8_t x, int8_t y)
+{
+    const uint32_t src = static_cast<uint32_t>(source);
+    if (src >= kSourceCount || slot >= kMaxControllerSlots) return;
+    x = static_cast<int8_t>(std::clamp<int>(x, -1, 1));
+    y = static_cast<int8_t>(std::clamp<int>(y, -1, 1));
+
+    StateListener cb;
+    LogicalGamepadState snap;
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (!enabled_) return;
+        slots_[slot].hatXBySource[src] = x;
+        slots_[slot].hatYBySource[src] = y;
+        RecomputeLocked(slot);
+        cb = listener_;
+        snap = slots_[slot].logical;
+    }
+    if (cb) cb(slot, snap);
+}
+
+void ControllerHub::ResetSource(ControllerSourceId source)
+{
+    const uint32_t src = static_cast<uint32_t>(source);
+    if (src >= kSourceCount) return;
+    const uint32_t bit = 1u << src;
+
+    StateListener cb;
+    LogicalGamepadState snaps[kMaxControllerSlots];
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        cb = listener_;
+        for (uint32_t slot = 0; slot < kMaxControllerSlots; ++slot) {
+            auto& st = slots_[slot];
+            for (uint32_t b = 0; b < kButtonCount; ++b) st.buttonOwners[b] &= ~bit;
+            for (uint32_t a = 0; a < kAxisCount; ++a) {
+                st.axisValues[src][a] = 0.f;
+                st.axisActive[src][a] = false;
+                if (st.axisOwner[a] == source) {
+                    st.axisOwner[a] = ControllerSourceId::Touch;
+                    for (uint32_t s = 0; s < kSourceCount; ++s) {
+                        if (st.axisActive[s][a]) {
+                            st.axisOwner[a] = static_cast<ControllerSourceId>(s);
+                            break;
+                        }
+                    }
+                }
+            }
+            st.hatXBySource[src] = 0;
+            st.hatYBySource[src] = 0;
+            RecomputeLocked(slot);
+            snaps[slot] = st.logical;
+        }
+    }
+    if (cb) {
+        for (uint32_t slot = 0; slot < kMaxControllerSlots; ++slot) cb(slot, snaps[slot]);
+    }
+}
+
+float ControllerHub::ApplyRadialDeadzone(float x, float y, float inner, float* outX, float* outY)
+{
+    const float mag = std::sqrt(x * x + y * y);
+    if (mag < inner || mag <= 0.f) {
+        *outX = 0.f;
+        *outY = 0.f;
+        return 0.f;
+    }
+    constexpr float outer = 0.98f;
+    float t = (mag - inner) / (outer - inner);
+    if (t > 1.f) t = 1.f;
+    const float scale = t / mag;
+    *outX = x * scale;
+    *outY = y * scale;
+    return t;
+}
+
+void ControllerHub::RecomputeLocked(uint32_t slot)
+{
+    auto& st = slots_[slot];
+    LogicalGamepadState next = st.logical;
+    next.buttons = 0;
+    for (uint32_t b = 0; b < 10; ++b) {  // A..R3 → WHGP bits 0..9
+        if (st.buttonOwners[b] != 0) next.buttons |= (1u << b);
+    }
+    if (st.buttonOwners[static_cast<uint32_t>(LogicalButton::Guide)] != 0) {
+        next.buttons |= (1u << 10);
+    }
+
+    auto emitStick = [&](LogicalAxis axX, LogicalAxis axY, int16_t* outX, int16_t* outY) {
+        const uint32_t aX = static_cast<uint32_t>(axX);
+        const uint32_t owner = static_cast<uint32_t>(st.axisOwner[aX]);
+        float ox = 0.f, oy = 0.f;
+        ApplyRadialDeadzone(st.axisValues[owner][aX],
+                            st.axisValues[owner][static_cast<uint32_t>(axY)],
+                            innerDeadzone_, &ox, &oy);
+        *outX = FloatToStick(ox);
+        *outY = FloatToStick(oy);
+    };
+    emitStick(LogicalAxis::LX, LogicalAxis::LY, &next.lx, &next.ly);
+    emitStick(LogicalAxis::RX, LogicalAxis::RY, &next.rx, &next.ry);
+
+    float lt = 0.f, rt = 0.f;
+    for (uint32_t s = 0; s < kSourceCount; ++s) {
+        lt = std::max(lt, st.axisValues[s][static_cast<uint32_t>(LogicalAxis::LT)]);
+        rt = std::max(rt, st.axisValues[s][static_cast<uint32_t>(LogicalAxis::RT)]);
+    }
+    next.lt = FloatToTrigger(lt);
+    next.rt = FloatToTrigger(rt);
+
+    // DPad: merge hat sources OR button dpad ownership into hat.
+    int hx = 0, hy = 0;
+    for (uint32_t s = 0; s < kSourceCount; ++s) {
+        if (st.hatXBySource[s] != 0) hx = st.hatXBySource[s];
+        if (st.hatYBySource[s] != 0) hy = st.hatYBySource[s];
+    }
+    if (st.buttonOwners[static_cast<uint32_t>(LogicalButton::DpadLeft)]) hx = -1;
+    if (st.buttonOwners[static_cast<uint32_t>(LogicalButton::DpadRight)]) hx = 1;
+    if (st.buttonOwners[static_cast<uint32_t>(LogicalButton::DpadUp)]) hy = 1;
+    if (st.buttonOwners[static_cast<uint32_t>(LogicalButton::DpadDown)]) hy = -1;
+    // If both left+right, prefer last non-zero from hats already; clamp conflict to 0.
+    if (st.buttonOwners[static_cast<uint32_t>(LogicalButton::DpadLeft)] &&
+        st.buttonOwners[static_cast<uint32_t>(LogicalButton::DpadRight)]) {
+        hx = 0;
+    }
+    if (st.buttonOwners[static_cast<uint32_t>(LogicalButton::DpadUp)] &&
+        st.buttonOwners[static_cast<uint32_t>(LogicalButton::DpadDown)]) {
+        hy = 0;
+    }
+    next.hatX = static_cast<int8_t>(hx);
+    next.hatY = static_cast<int8_t>(hy);
+
+    if (next.buttons != st.logical.buttons || next.lx != st.logical.lx || next.ly != st.logical.ly ||
+        next.rx != st.logical.rx || next.ry != st.logical.ry || next.lt != st.logical.lt ||
+        next.rt != st.logical.rt || next.hatX != st.logical.hatX || next.hatY != st.logical.hatY) {
+        next.sequence = st.logical.sequence + 1;
+        st.logical = next;
+    }
+}
+
+}  // namespace controller
+}  // namespace winehua

--- a/entry/src/main/cpp/input/controller/controller_hub.h
+++ b/entry/src/main/cpp/input/controller/controller_hub.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include "input/controller/controller_types.h"
+
+#include <atomic>
+#include <functional>
+#include <mutex>
+
+namespace winehua {
+namespace controller {
+
+// Slot merge + logical state. Thread-safe; Physical kit callbacks and NAPI
+// (Touch) may call from different threads.
+class ControllerHub {
+public:
+    using StateListener = std::function<void(uint32_t slot, const LogicalGamepadState&)>;
+
+    static ControllerHub& Instance();
+
+    void SetEnabled(bool enabled);
+    bool IsEnabled() const;
+
+    void SetButton(ControllerSourceId source, uint32_t slot, LogicalButton button, bool pressed);
+    // value in [-1,1] for sticks, [0,1] for triggers. +Y = Up.
+    void SetAxis(ControllerSourceId source, uint32_t slot, LogicalAxis axis, float value);
+    void SetHat(ControllerSourceId source, uint32_t slot, int8_t x, int8_t y);
+    void ResetSource(ControllerSourceId source);
+
+    LogicalGamepadState GetState(uint32_t slot) const;
+    void SetStateListener(StateListener listener);
+
+    // Deadzone applied to physical/touch stick axes before merge (radial).
+    void SetInnerDeadzone(float inner);
+
+private:
+    ControllerHub() = default;
+
+    struct SlotState {
+        uint32_t buttonOwners[kButtonCount] = {};
+        float axisValues[kSourceCount][kAxisCount] = {};
+        bool axisActive[kSourceCount][kAxisCount] = {};
+        ControllerSourceId axisOwner[kAxisCount] = {
+            ControllerSourceId::Touch, ControllerSourceId::Touch, ControllerSourceId::Touch,
+            ControllerSourceId::Touch, ControllerSourceId::Touch, ControllerSourceId::Touch};
+        int8_t hatXBySource[kSourceCount] = {};
+        int8_t hatYBySource[kSourceCount] = {};
+        LogicalGamepadState logical;
+    };
+
+    void RecomputeLocked(uint32_t slot);
+    static float ApplyRadialDeadzone(float x, float y, float inner, float* outX, float* outY);
+
+    mutable std::mutex mutex_;
+    bool enabled_ = false;
+    float innerDeadzone_ = 0.10f;
+    SlotState slots_[kMaxControllerSlots];
+    StateListener listener_;
+};
+
+}  // namespace controller
+}  // namespace winehua

--- a/entry/src/main/cpp/input/controller/controller_napi.cpp
+++ b/entry/src/main/cpp/input/controller/controller_napi.cpp
@@ -1,0 +1,222 @@
+#include "input/controller/controller_napi.h"
+
+#include "input/controller/controller_hub.h"
+#include "input/controller/controller_runtime.h"
+#include "input/controller/gamepad_bridge.h"
+
+#include <cstdio>
+#include <string>
+
+using winehua::controller::ControllerHub;
+using winehua::controller::ControllerSourceId;
+using winehua::controller::GamepadBridge;
+using winehua::controller::LogicalAxis;
+using winehua::controller::LogicalButton;
+using winehua::controller::LogicalGamepadState;
+
+namespace {
+
+bool ReadBool(napi_env env, napi_value v, bool* out)
+{
+    return napi_get_value_bool(env, v, out) == napi_ok;
+}
+
+bool ReadInt32(napi_env env, napi_value v, int32_t* out)
+{
+    return napi_get_value_int32(env, v, out) == napi_ok;
+}
+
+bool ReadDouble(napi_env env, napi_value v, double* out)
+{
+    return napi_get_value_double(env, v, out) == napi_ok;
+}
+
+bool ReadUtf8(napi_env env, napi_value v, std::string* out)
+{
+    size_t len = 0;
+    if (napi_get_value_string_utf8(env, v, nullptr, 0, &len) != napi_ok) return false;
+    out->resize(len);
+    return napi_get_value_string_utf8(env, v, out->data(), len + 1, &len) == napi_ok;
+}
+
+}  // namespace
+
+napi_value ControllerSetEnabled(napi_env env, napi_callback_info info)
+{
+    size_t argc = 1;
+    napi_value args[1] = {};
+    napi_get_cb_info(env, info, &argc, args, nullptr, nullptr);
+    bool enabled = false;
+    if (argc >= 1) ReadBool(env, args[0], &enabled);
+    ControllerHub::Instance().SetEnabled(enabled);
+    if (enabled) GamepadBridge::Instance().AttachToHub();
+    return nullptr;
+}
+
+napi_value ControllerSetButton(napi_env env, napi_callback_info info)
+{
+    size_t argc = 4;
+    napi_value args[4] = {};
+    napi_get_cb_info(env, info, &argc, args, nullptr, nullptr);
+    int32_t source = 0, slot = 0, button = 0;
+    bool pressed = false;
+    if (argc < 4) return nullptr;
+    ReadInt32(env, args[0], &source);
+    ReadInt32(env, args[1], &slot);
+    ReadInt32(env, args[2], &button);
+    ReadBool(env, args[3], &pressed);
+    ControllerHub::Instance().SetButton(static_cast<ControllerSourceId>(source),
+                                        static_cast<uint32_t>(slot),
+                                        static_cast<LogicalButton>(button), pressed);
+    return nullptr;
+}
+
+napi_value ControllerSetAxis(napi_env env, napi_callback_info info)
+{
+    size_t argc = 4;
+    napi_value args[4] = {};
+    napi_get_cb_info(env, info, &argc, args, nullptr, nullptr);
+    int32_t source = 0, slot = 0, axis = 0;
+    double value = 0;
+    if (argc < 4) return nullptr;
+    ReadInt32(env, args[0], &source);
+    ReadInt32(env, args[1], &slot);
+    ReadInt32(env, args[2], &axis);
+    ReadDouble(env, args[3], &value);
+    ControllerHub::Instance().SetAxis(static_cast<ControllerSourceId>(source),
+                                      static_cast<uint32_t>(slot),
+                                      static_cast<LogicalAxis>(axis),
+                                      static_cast<float>(value));
+    return nullptr;
+}
+
+napi_value ControllerSetHat(napi_env env, napi_callback_info info)
+{
+    size_t argc = 4;
+    napi_value args[4] = {};
+    napi_get_cb_info(env, info, &argc, args, nullptr, nullptr);
+    int32_t source = 0, slot = 0, x = 0, y = 0;
+    if (argc < 4) return nullptr;
+    ReadInt32(env, args[0], &source);
+    ReadInt32(env, args[1], &slot);
+    ReadInt32(env, args[2], &x);
+    ReadInt32(env, args[3], &y);
+    ControllerHub::Instance().SetHat(static_cast<ControllerSourceId>(source),
+                                     static_cast<uint32_t>(slot),
+                                     static_cast<int8_t>(x), static_cast<int8_t>(y));
+    return nullptr;
+}
+
+napi_value ControllerResetSource(napi_env env, napi_callback_info info)
+{
+    size_t argc = 1;
+    napi_value args[1] = {};
+    napi_get_cb_info(env, info, &argc, args, nullptr, nullptr);
+    int32_t source = 0;
+    if (argc >= 1) ReadInt32(env, args[0], &source);
+    ControllerHub::Instance().ResetSource(static_cast<ControllerSourceId>(source));
+    return nullptr;
+}
+
+napi_value ControllerGetState(napi_env env, napi_callback_info info)
+{
+    size_t argc = 1;
+    napi_value args[1] = {};
+    napi_get_cb_info(env, info, &argc, args, nullptr, nullptr);
+    int32_t slot = 0;
+    if (argc >= 1) ReadInt32(env, args[0], &slot);
+    const LogicalGamepadState st = ControllerHub::Instance().GetState(static_cast<uint32_t>(slot));
+    napi_value obj;
+    napi_create_object(env, &obj);
+    auto setInt = [&](const char* key, int64_t value) {
+        napi_value v, k;
+        napi_create_int64(env, value, &v);
+        napi_create_string_utf8(env, key, NAPI_AUTO_LENGTH, &k);
+        napi_set_property(env, obj, k, v);
+    };
+    setInt("buttons", st.buttons);
+    setInt("lx", st.lx);
+    setInt("ly", st.ly);
+    setInt("rx", st.rx);
+    setInt("ry", st.ry);
+    setInt("lt", st.lt);
+    setInt("rt", st.rt);
+    setInt("hatX", st.hatX);
+    setInt("hatY", st.hatY);
+    setInt("sequence", static_cast<int64_t>(st.sequence));
+    return obj;
+}
+
+napi_value ControllerGetStateText(napi_env env, napi_callback_info info)
+{
+    size_t argc = 1;
+    napi_value args[1] = {};
+    napi_get_cb_info(env, info, &argc, args, nullptr, nullptr);
+    int32_t slot = 0;
+    if (argc >= 1) ReadInt32(env, args[0], &slot);
+    const LogicalGamepadState st = ControllerHub::Instance().GetState(static_cast<uint32_t>(slot));
+    char buf[192];
+    std::snprintf(buf, sizeof(buf),
+                  "btn=0x%x LX=%d LY=%d RX=%d RY=%d LT=%u RT=%u hat=%d,%d seq=%llu",
+                  st.buttons, st.lx, st.ly, st.rx, st.ry,
+                  st.lt, st.rt, st.hatX, st.hatY,
+                  static_cast<unsigned long long>(st.sequence));
+    napi_value result;
+    napi_create_string_utf8(env, buf, NAPI_AUTO_LENGTH, &result);
+    return result;
+}
+
+napi_value ControllerStartBridge(napi_env env, napi_callback_info info)
+{
+    size_t argc = 1;
+    napi_value args[1] = {};
+    napi_get_cb_info(env, info, &argc, args, nullptr, nullptr);
+    std::string path;
+    if (argc >= 1) ReadUtf8(env, args[0], &path);
+    GamepadBridge::Instance().AttachToHub();
+    const bool ok = GamepadBridge::Instance().Start(path);
+    napi_value result;
+    napi_get_boolean(env, ok, &result);
+    return result;
+}
+
+napi_value ControllerStopBridge(napi_env, napi_callback_info)
+{
+    GamepadBridge::Instance().Stop();
+    return nullptr;
+}
+
+napi_value ControllerGetSocketPath(napi_env env, napi_callback_info)
+{
+    const std::string path = GamepadBridge::Instance().SocketPath();
+    napi_value result;
+    napi_create_string_utf8(env, path.c_str(), NAPI_AUTO_LENGTH, &result);
+    return result;
+}
+
+napi_value ControllerSetOutputMode(napi_env env, napi_callback_info info)
+{
+    size_t argc = 1;
+    napi_value args[1] = {};
+    napi_get_cb_info(env, info, &argc, args, nullptr, nullptr);
+    std::string mode;
+    if (argc >= 1) ReadUtf8(env, args[0], &mode);
+    winehua::controller::SetOutputMode(mode);
+    if (winehua::controller::IsDinputMode()) {
+        ControllerHub::Instance().SetEnabled(true);
+    } else {
+        ControllerHub::Instance().ResetSource(ControllerSourceId::Touch);
+        ControllerHub::Instance().ResetSource(ControllerSourceId::Physical);
+        GamepadBridge::Instance().Stop();
+        ControllerHub::Instance().SetEnabled(false);
+    }
+    return nullptr;
+}
+
+napi_value ControllerGetOutputMode(napi_env env, napi_callback_info)
+{
+    const std::string mode = winehua::controller::GetOutputMode();
+    napi_value result;
+    napi_create_string_utf8(env, mode.c_str(), NAPI_AUTO_LENGTH, &result);
+    return result;
+}

--- a/entry/src/main/cpp/input/controller/controller_napi.h
+++ b/entry/src/main/cpp/input/controller/controller_napi.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <napi/native_api.h>
+
+// Controller Hub NAPI (Touch source + enable/WHGP bootstrap).
+napi_value ControllerSetEnabled(napi_env env, napi_callback_info info);
+napi_value ControllerSetButton(napi_env env, napi_callback_info info);
+napi_value ControllerSetAxis(napi_env env, napi_callback_info info);
+napi_value ControllerSetHat(napi_env env, napi_callback_info info);
+napi_value ControllerResetSource(napi_env env, napi_callback_info info);
+napi_value ControllerGetState(napi_env env, napi_callback_info info);
+napi_value ControllerGetStateText(napi_env env, napi_callback_info info);
+napi_value ControllerStartBridge(napi_env env, napi_callback_info info);
+napi_value ControllerStopBridge(napi_env env, napi_callback_info info);
+napi_value ControllerGetSocketPath(napi_env env, napi_callback_info info);
+napi_value ControllerSetOutputMode(napi_env env, napi_callback_info info);
+napi_value ControllerGetOutputMode(napi_env env, napi_callback_info info);

--- a/entry/src/main/cpp/input/controller/controller_runtime.cpp
+++ b/entry/src/main/cpp/input/controller/controller_runtime.cpp
@@ -1,0 +1,70 @@
+#include "input/controller/controller_runtime.h"
+
+#include "input/controller/controller_hub.h"
+#include "input/controller/gamepad_bridge.h"
+#include "input/game_controller_bridge.h"
+
+#include <mutex>
+
+namespace winehua {
+namespace controller {
+namespace {
+
+std::mutex gModeMutex;
+std::string gOutputMode = "dinput";
+
+}  // namespace
+
+void SetOutputMode(const std::string& mode)
+{
+    std::lock_guard<std::mutex> lock(gModeMutex);
+    if (mode == "keyboard_legacy") gOutputMode = "keyboard_legacy";
+    else gOutputMode = "dinput";
+}
+
+std::string GetOutputMode()
+{
+    std::lock_guard<std::mutex> lock(gModeMutex);
+    return gOutputMode;
+}
+
+bool IsDinputMode()
+{
+    return GetOutputMode() == "dinput";
+}
+
+bool EnsureBridgeForWineLaunch(const std::string& runtimeDir)
+{
+    if (!IsDinputMode()) {
+        GamepadBridge::Instance().Stop();
+        ControllerHub::Instance().SetEnabled(false);
+        return false;
+    }
+    std::string sock = runtimeDir.empty() ? std::string("/data/storage/el2/base/files/.wine") : runtimeDir;
+    if (!sock.empty() && sock.back() != '/') sock += '/';
+    sock += "whgp.sock";
+    // master has no product GamepadManager lifecycle. Keep the Native Host
+    // functional on its own; devices without the Kit degrade to touch input.
+    EnsurePhysicalGamepadInitialized();
+    ControllerHub::Instance().SetEnabled(true);
+    GamepadBridge::Instance().AttachToHub();
+    return GamepadBridge::Instance().Start(sock);
+}
+
+void AppendWineGamepadEnv(std::vector<std::string>& env)
+{
+    if (!IsDinputMode()) {
+        env.push_back("WINEHUA_CONTROLLER_HUB=0");
+        env.push_back("WINEHUA_GAMEPAD_ENABLE=0");
+        env.push_back("WINEHUA_GAMEPAD_MODE=keyboard_legacy");
+        return;
+    }
+    const std::string path = GamepadBridge::Instance().SocketPath();
+    env.push_back("WINEHUA_CONTROLLER_HUB=1");
+    env.push_back("WINEHUA_GAMEPAD_ENABLE=1");
+    env.push_back("WINEHUA_GAMEPAD_MODE=dinput");
+    if (!path.empty()) env.push_back("WINEHUA_GAMEPAD_SOCKET=" + path);
+}
+
+}  // namespace controller
+}  // namespace winehua

--- a/entry/src/main/cpp/input/controller/controller_runtime.h
+++ b/entry/src/main/cpp/input/controller/controller_runtime.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace winehua {
+namespace controller {
+
+// "dinput" (default) | "keyboard_legacy"
+void SetOutputMode(const std::string& mode);
+std::string GetOutputMode();
+bool IsDinputMode();
+
+// Called from wine launch path: start WHGP + enable hub when dinput.
+bool EnsureBridgeForWineLaunch(const std::string& runtimeDir);
+void AppendWineGamepadEnv(std::vector<std::string>& env);
+
+}  // namespace controller
+}  // namespace winehua

--- a/entry/src/main/cpp/input/controller/controller_types.h
+++ b/entry/src/main/cpp/input/controller/controller_types.h
@@ -1,0 +1,97 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+// WineHua Controller Hub — logical gamepad types.
+// Stick: int16 [-32768, 32767], +Y = Up.
+// Trigger: uint16 [0, 32767].
+// Hat: int8 -1 / 0 / +1.
+
+namespace winehua {
+namespace controller {
+
+enum class LogicalButton : uint8_t {
+    A = 0,
+    B,
+    X,
+    Y,
+    LB,
+    RB,
+    Back,
+    Start,
+    L3,
+    R3,
+    DpadUp,
+    DpadRight,
+    DpadDown,
+    DpadLeft,
+    Guide,
+    Count
+};
+
+enum class LogicalAxis : uint8_t {
+    LX = 0,
+    LY,
+    RX,
+    RY,
+    LT,
+    RT,
+    Count
+};
+
+enum class ControllerSourceType : uint8_t {
+    Touch = 0,
+    Physical = 1,
+    Keyboard = 2,
+    Macro = 3,
+};
+
+// Fixed source ids for MVP (bit indices in ownership masks).
+enum class ControllerSourceId : uint8_t {
+    Touch = 0,
+    Physical = 1,
+    Keyboard = 2,
+    Count = 3,
+};
+
+static constexpr uint32_t kMaxControllerSlots = 4;
+static constexpr uint32_t kButtonCount = static_cast<uint32_t>(LogicalButton::Count);
+static constexpr uint32_t kAxisCount = static_cast<uint32_t>(LogicalAxis::Count);
+static constexpr uint32_t kSourceCount = static_cast<uint32_t>(ControllerSourceId::Count);
+
+struct LogicalGamepadState {
+    uint32_t buttons = 0;  // bit i = LogicalButton(i) for i < 10 (A..R3); dpad via hat
+    int16_t lx = 0;
+    int16_t ly = 0;
+    int16_t rx = 0;
+    int16_t ry = 0;
+    uint16_t lt = 0;
+    uint16_t rt = 0;
+    int8_t hatX = 0;
+    int8_t hatY = 0;
+    uint64_t sequence = 0;
+};
+
+inline uint32_t ButtonBit(LogicalButton b)
+{
+    return 1u << static_cast<uint32_t>(b);
+}
+
+inline int16_t FloatToStick(float v)
+{
+    if (v > 1.f) v = 1.f;
+    if (v < -1.f) v = -1.f;
+    if (v >= 0.f) return static_cast<int16_t>(v * 32767.f);
+    return static_cast<int16_t>(v * 32768.f);
+}
+
+inline uint16_t FloatToTrigger(float v)
+{
+    if (v < 0.f) v = 0.f;
+    if (v > 1.f) v = 1.f;
+    return static_cast<uint16_t>(v * 32767.f);
+}
+
+}  // namespace controller
+}  // namespace winehua

--- a/entry/src/main/cpp/input/controller/gamepad_bridge.cpp
+++ b/entry/src/main/cpp/input/controller/gamepad_bridge.cpp
@@ -1,0 +1,285 @@
+#include "input/controller/gamepad_bridge.h"
+
+#include "input/controller/controller_hub.h"
+#include "input/controller/gamepad_ipc_protocol.h"
+
+#include <cerrno>
+#include <cstdint>
+#include <cstring>
+#include <fcntl.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/uio.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+#undef LOG_TAG
+#define LOG_TAG "CtrlHub"
+#include <hilog/log.h>
+
+namespace winehua {
+namespace controller {
+
+namespace {
+
+bool ReadExact(int fd, void* buf, size_t len)
+{
+    auto* p = static_cast<uint8_t*>(buf);
+    size_t got = 0;
+    while (got < len) {
+        const ssize_t n = read(fd, p + got, len - got);
+        if (n == 0) return false;
+        if (n < 0) {
+            if (errno == EINTR) continue;
+            return false;
+        }
+        got += static_cast<size_t>(n);
+    }
+    return true;
+}
+
+}  // namespace
+
+GamepadBridge& GamepadBridge::Instance()
+{
+    static GamepadBridge bridge;
+    return bridge;
+}
+
+std::string GamepadBridge::SocketPath() const
+{
+    std::lock_guard<std::mutex> lock(mutex_);
+    return path_;
+}
+
+bool GamepadBridge::IsRunning() const
+{
+    std::lock_guard<std::mutex> lock(mutex_);
+    return running_;
+}
+
+void GamepadBridge::SetRumbleListener(RumbleListener cb)
+{
+    std::lock_guard<std::mutex> lock(mutex_);
+    rumbleListener_ = std::move(cb);
+}
+
+bool GamepadBridge::Start(const std::string& socketPath)
+{
+    std::string path = socketPath;
+    if (path.empty()) {
+        path = "/data/storage/el2/base/files/.wine/whgp.sock";
+    }
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (running_ && listenFd_ >= 0 && path_ == path) {
+            OH_LOG_INFO(LOG_APP, "[WHGP] already listening on %{public}s", path.c_str());
+            return true;
+        }
+    }
+    Stop();
+
+    unlink(path.c_str());
+    const int fd = socket(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0);
+    if (fd < 0) {
+        OH_LOG_ERROR(LOG_APP, "[WHGP] socket failed errno=%{public}d", errno);
+        return false;
+    }
+
+    sockaddr_un addr{};
+    addr.sun_family = AF_UNIX;
+    if (path.size() >= sizeof(addr.sun_path)) {
+        close(fd);
+        return false;
+    }
+    std::strncpy(addr.sun_path, path.c_str(), sizeof(addr.sun_path) - 1);
+
+    if (bind(fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) != 0) {
+        OH_LOG_ERROR(LOG_APP, "[WHGP] bind %{public}s failed errno=%{public}d", path.c_str(), errno);
+        close(fd);
+        return false;
+    }
+    chmod(path.c_str(), 0666);
+    if (listen(fd, 1) != 0) {
+        close(fd);
+        unlink(path.c_str());
+        return false;
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        listenFd_ = fd;
+        path_ = path;
+        running_ = true;
+    }
+    acceptThread_ = std::thread([this] { AcceptLoop(); });
+    OH_LOG_INFO(LOG_APP, "[WHGP] listening on %{public}s", path.c_str());
+    return true;
+}
+
+void GamepadBridge::Stop()
+{
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        running_ = false;
+        if (listenFd_ >= 0) {
+            shutdown(listenFd_, SHUT_RDWR);
+            close(listenFd_);
+            listenFd_ = -1;
+        }
+        if (clientFd_ >= 0) {
+            shutdown(clientFd_, SHUT_RDWR);
+            clientFd_ = -1;
+        }
+        if (!path_.empty()) unlink(path_.c_str());
+    }
+    if (acceptThread_.joinable()) acceptThread_.join();
+    if (rumbleThread_.joinable()) rumbleThread_.join();
+}
+
+void GamepadBridge::AcceptLoop()
+{
+    while (true) {
+        int listenFd = -1;
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            if (!running_) return;
+            listenFd = listenFd_;
+        }
+        int client = accept4(listenFd, nullptr, nullptr, SOCK_CLOEXEC);
+        if (client < 0 && (errno == ENOSYS || errno == EINVAL || errno == EOPNOTSUPP)) {
+            client = accept(listenFd, nullptr, nullptr);
+            if (client >= 0) fcntl(client, F_SETFD, FD_CLOEXEC);
+        }
+        if (client < 0) {
+            if (errno == EINTR) continue;
+            std::lock_guard<std::mutex> lock(mutex_);
+            if (!running_) return;
+            continue;
+        }
+
+        int oldClient = -1;
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            oldClient = clientFd_;
+            clientFd_ = -1;
+            if (oldClient >= 0) shutdown(oldClient, SHUT_RDWR);
+        }
+        if (rumbleThread_.joinable()) rumbleThread_.join();
+
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            if (!running_) {
+                close(client);
+                return;
+            }
+            clientFd_ = client;
+            OH_LOG_INFO(LOG_APP, "[WHGP] client connected fd=%{public}d", client);
+        }
+        rumbleThread_ = std::thread([this, client] { RecvLoop(client); });
+        PublishState(0, ControllerHub::Instance().GetState(0));
+    }
+}
+
+void GamepadBridge::RecvLoop(int fd)
+{
+    while (true) {
+        whgp_header hdr{};
+        if (!ReadExact(fd, &hdr, sizeof(hdr))) break;
+        if (hdr.magic != WHGP_MAGIC || hdr.version != WHGP_VERSION) {
+            OH_LOG_WARN(LOG_APP, "[WHGP] bad header from winebus magic=%{public}u ver=%{public}u",
+                        hdr.magic, hdr.version);
+            break;
+        }
+        if (hdr.payload_size > 4096) {
+            OH_LOG_WARN(LOG_APP, "[WHGP] payload too large %{public}u", hdr.payload_size);
+            break;
+        }
+
+        if (hdr.msg_type == WHGP_MSG_RUMBLE && hdr.payload_size == sizeof(whgp_rumble_v1)) {
+            whgp_rumble_v1 body{};
+            if (!ReadExact(fd, &body, sizeof(body))) break;
+            RumbleListener cb;
+            {
+                std::lock_guard<std::mutex> lock(mutex_);
+                cb = rumbleListener_;
+            }
+            if (cb) cb(body.low, body.high, body.duration_ms);
+            continue;
+        }
+
+        uint32_t left = hdr.payload_size;
+        uint8_t discard[256];
+        bool ok = true;
+        while (left) {
+            const uint32_t chunk = left > sizeof(discard) ? static_cast<uint32_t>(sizeof(discard)) : left;
+            if (!ReadExact(fd, discard, chunk)) {
+                ok = false;
+                break;
+            }
+            left -= chunk;
+        }
+        if (!ok) break;
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (clientFd_ == fd) clientFd_ = -1;
+    }
+    close(fd);
+    OH_LOG_INFO(LOG_APP, "[WHGP] client recv loop exited fd=%{public}d", fd);
+}
+
+void GamepadBridge::WriteState(int fd, uint32_t slot, const LogicalGamepadState& state)
+{
+    whgp_header hdr{};
+    hdr.magic = WHGP_MAGIC;
+    hdr.version = WHGP_VERSION;
+    hdr.msg_type = WHGP_MSG_STATE;
+    hdr.slot = slot;
+    hdr.payload_size = sizeof(whgp_state_v1);
+
+    whgp_state_v1 body{};
+    body.buttons = state.buttons;
+    body.lx = state.lx;
+    body.ly = state.ly;
+    body.rx = state.rx;
+    body.ry = state.ry;
+    body.lt = state.lt;
+    body.rt = state.rt;
+    body.hat_x = state.hatX;
+    body.hat_y = state.hatY;
+
+    const ssize_t total = static_cast<ssize_t>(sizeof(hdr) + sizeof(body));
+    iovec iov[2] = {
+        {&hdr, sizeof(hdr)},
+        {&body, sizeof(body)},
+    };
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (clientFd_ != fd) return;
+    if (writev(fd, iov, 2) != total) {
+        shutdown(fd, SHUT_RDWR);
+        if (clientFd_ == fd) clientFd_ = -1;
+    }
+}
+
+void GamepadBridge::PublishState(uint32_t slot, const LogicalGamepadState& state)
+{
+    int fd = -1;
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        fd = clientFd_;
+    }
+    if (fd < 0) return;
+    WriteState(fd, slot, state);
+}
+
+void GamepadBridge::AttachToHub()
+{
+    ControllerHub::Instance().SetEnabled(true);
+    ControllerHub::Instance().SetStateListener(
+        [this](uint32_t slot, const LogicalGamepadState& state) { PublishState(slot, state); });
+}
+
+}  // namespace controller
+}  // namespace winehua

--- a/entry/src/main/cpp/input/controller/gamepad_bridge.h
+++ b/entry/src/main/cpp/input/controller/gamepad_bridge.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include "input/controller/controller_types.h"
+
+#include <cstdint>
+#include <functional>
+#include <mutex>
+#include <string>
+#include <thread>
+
+namespace winehua {
+namespace controller {
+
+// AF_UNIX WHGP server. Hub state listener pushes snapshots to connected winebus
+// clients; rumble packets from winebus are forwarded to a JS/native listener.
+class GamepadBridge {
+public:
+    using RumbleListener = std::function<void(uint16_t low, uint16_t high, uint32_t durationMs)>;
+
+    static GamepadBridge& Instance();
+
+    bool Start(const std::string& socketPath);
+    void Stop();
+    bool IsRunning() const;
+    std::string SocketPath() const;
+    void PublishState(uint32_t slot, const LogicalGamepadState& state);
+    void AttachToHub();
+    void SetRumbleListener(RumbleListener cb);
+
+private:
+    GamepadBridge() = default;
+    void AcceptLoop();
+    void RecvLoop(int fd);
+    void WriteState(int fd, uint32_t slot, const LogicalGamepadState& state);
+
+    mutable std::mutex mutex_;
+    std::string path_;
+    int listenFd_ = -1;
+    int clientFd_ = -1;
+    bool running_ = false;
+    std::thread acceptThread_;
+    std::thread rumbleThread_;
+    RumbleListener rumbleListener_;
+};
+
+}  // namespace controller
+}  // namespace winehua

--- a/entry/src/main/cpp/input/controller/gamepad_ipc_protocol.h
+++ b/entry/src/main/cpp/input/controller/gamepad_ipc_protocol.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* WineHua Gamepad Protocol (WHGP) v1 — host <-> winebus bus_ohos.
+ * Keep in sync with thirdparty/wine/dlls/winebus.sys/winehua_gamepad_protocol.h
+ */
+
+#define WHGP_MAGIC 0x50474857u /* 'WHGP' LE */
+#define WHGP_VERSION 1
+#define WHGP_MSG_STATE 1
+#define WHGP_MSG_RESET 2
+#define WHGP_MSG_RUMBLE 3
+
+#pragma pack(push, 1)
+struct whgp_header {
+    uint32_t magic;
+    uint16_t version;
+    uint16_t msg_type;
+    uint32_t slot;
+    uint32_t payload_size;
+};
+
+struct whgp_state_v1 {
+    uint32_t buttons; /* bit0=A ... bit9=R3 */
+    int16_t lx;
+    int16_t ly;
+    int16_t rx;
+    int16_t ry;
+    uint16_t lt; /* 0..32767 */
+    uint16_t rt;
+    int8_t hat_x; /* -1/0/+1 */
+    int8_t hat_y;
+    uint8_t reserved[2];
+};
+
+/* Wine → host. duration_ms 0 means "until next update"; host uses a short pulse. */
+struct whgp_rumble_v1 {
+    uint16_t low;  /* left / rumble motor, 0..65535 */
+    uint16_t high; /* right / buzz motor, 0..65535 */
+    uint32_t duration_ms;
+};
+#pragma pack(pop)
+
+#ifdef __cplusplus
+}
+#endif

--- a/entry/src/main/cpp/input/controller/physical_gamepad.cpp
+++ b/entry/src/main/cpp/input/controller/physical_gamepad.cpp
@@ -1,0 +1,100 @@
+#include "input/controller/physical_gamepad.h"
+
+#include "input/controller/controller_hub.h"
+#include "input/controller/controller_runtime.h"
+#include "input/controller/controller_types.h"
+
+namespace winehua {
+namespace controller {
+namespace {
+
+LogicalButton MapOhButton(int code)
+{
+    switch (code) {
+        case 2301: return LogicalButton::A;
+        case 2302: return LogicalButton::B;
+        case 2304: return LogicalButton::X;
+        case 2305: return LogicalButton::Y;
+        case 2307: return LogicalButton::LB;
+        case 2308: return LogicalButton::RB;
+        case 2309: return LogicalButton::LB; // L2 button → also drive LT via SetAxis below
+        case 2310: return LogicalButton::RB;
+        case 2311: return LogicalButton::Back;
+        case 2312: return LogicalButton::Start;
+        case 2313: return LogicalButton::L3;
+        case 2314: return LogicalButton::R3;
+        case 2315: return LogicalButton::Guide;
+        case 2012: return LogicalButton::DpadUp;
+        case 2013: return LogicalButton::DpadDown;
+        case 2014: return LogicalButton::DpadLeft;
+        case 2015: return LogicalButton::DpadRight;
+        default: return LogicalButton::Count;
+    }
+}
+
+}  // namespace
+
+void PhysicalFeedButton(int ohButtonCode, bool pressed)
+{
+    if (!ControllerHub::Instance().IsEnabled()) return;
+    // Trigger buttons: prefer axis; also set axis 1.0/0 as fallback.
+    if (ohButtonCode == 2309) {
+        ControllerHub::Instance().SetAxis(ControllerSourceId::Physical, 0, LogicalAxis::LT,
+                                          pressed ? 1.f : 0.f);
+        return;
+    }
+    if (ohButtonCode == 2310) {
+        ControllerHub::Instance().SetAxis(ControllerSourceId::Physical, 0, LogicalAxis::RT,
+                                          pressed ? 1.f : 0.f);
+        return;
+    }
+    const LogicalButton btn = MapOhButton(ohButtonCode);
+    if (btn == LogicalButton::Count) return;
+    ControllerHub::Instance().SetButton(ControllerSourceId::Physical, 0, btn, pressed);
+}
+
+void PhysicalFeedAxis(int axisType, double x, double y)
+{
+    if (!ControllerHub::Instance().IsEnabled()) return;
+    auto& hub = ControllerHub::Instance();
+    const float fx = static_cast<float>(x);
+    const float fy = static_cast<float>(y);
+    auto feedThumb = [&](LogicalAxis axisX, LogicalAxis axisY) {
+        hub.SetAxis(ControllerSourceId::Physical, 0, axisX, fx);
+        hub.SetAxis(ControllerSourceId::Physical, 0, axisY, fy);
+    };
+    switch (axisType) {
+        case 0: // left stick
+            feedThumb(LogicalAxis::LX, LogicalAxis::LY);
+            break;
+        case 1: // right stick
+            feedThumb(LogicalAxis::RX, LogicalAxis::RY);
+            break;
+        case 2: { // hat / dpad axis — values typically -1..1
+            const int8_t hx = (x < -0.5) ? -1 : (x > 0.5 ? 1 : 0);
+            // Hat: Kit +Y is Down → Hub +Y=Up. Analog thumbs are not flipped:
+            // left and right share feedThumb; winebus already inverts stick Y.
+            const int8_t hy = (y > 0.5) ? -1 : (y < -0.5 ? 1 : 0);
+            hub.SetHat(ControllerSourceId::Physical, 0, hx, hy);
+            break;
+        }
+        case 3: // LT brake [0,1]
+            hub.SetAxis(ControllerSourceId::Physical, 0, LogicalAxis::LT, static_cast<float>(x));
+            break;
+        case 4: // RT gas
+            hub.SetAxis(ControllerSourceId::Physical, 0, LogicalAxis::RT, static_cast<float>(x));
+            break;
+        default:
+            break;
+    }
+}
+
+void PhysicalFeedDevice(bool connected)
+{
+    if (!connected) {
+        ControllerHub::Instance().ResetSource(ControllerSourceId::Physical);
+    }
+}
+
+}  // namespace controller
+}  // namespace winehua

--- a/entry/src/main/cpp/input/controller/physical_gamepad.h
+++ b/entry/src/main/cpp/input/controller/physical_gamepad.h
@@ -1,0 +1,12 @@
+#pragma once
+
+namespace winehua {
+namespace controller {
+
+// Feed Game Controller Kit events into ControllerHub (Physical source).
+void PhysicalFeedButton(int ohButtonCode, bool pressed);
+void PhysicalFeedAxis(int axisType, double x, double y);
+void PhysicalFeedDevice(bool connected);
+
+}  // namespace controller
+}  // namespace winehua

--- a/entry/src/main/cpp/input/game_controller_bridge.cpp
+++ b/entry/src/main/cpp/input/game_controller_bridge.cpp
@@ -1,0 +1,379 @@
+#include "input/game_controller_bridge.h"
+
+#include "input/controller/gamepad_bridge.h"
+#include "input/controller/physical_gamepad.h"
+
+#include <dlfcn.h>
+#include <atomic>
+#include <cstdint>
+#include <mutex>
+#include <string>
+#include <vector>
+
+#undef LOG_TAG
+#define LOG_TAG "WineGamepad"
+#include <hilog/log.h>
+
+namespace {
+
+using ErrorCode = int;
+using ButtonAction = int;
+struct ButtonEvent;
+struct AxisEvent;
+struct DeviceEvent;
+struct DeviceInfos;
+using ButtonCallback = void (*)(const ButtonEvent*);
+using AxisCallback = void (*)(const AxisEvent*);
+using DeviceCallback = void (*)(const DeviceEvent*);
+using RegisterButton = ErrorCode (*)(ButtonCallback);
+using RegisterAxis = ErrorCode (*)(AxisCallback);
+using Unregister = void (*)();
+
+void* gLibrary = nullptr;
+bool gInitialized = false;
+std::atomic<int> gDeviceCount{0};
+std::mutex gMutex;
+std::vector<Unregister> gUnregisterFunctions;
+napi_threadsafe_function gButtonTsfn = nullptr;
+napi_threadsafe_function gAxisTsfn = nullptr;
+napi_threadsafe_function gDeviceTsfn = nullptr;
+napi_threadsafe_function gRumbleTsfn = nullptr;
+
+ErrorCode (*gGetButtonAction)(const ButtonEvent*, ButtonAction*) = nullptr;
+ErrorCode (*gGetButtonCode)(const ButtonEvent*, int*) = nullptr;
+ErrorCode (*gGetX)(const AxisEvent*, double*) = nullptr;
+ErrorCode (*gGetY)(const AxisEvent*, double*) = nullptr;
+ErrorCode (*gGetZ)(const AxisEvent*, double*) = nullptr;
+ErrorCode (*gGetRz)(const AxisEvent*, double*) = nullptr;
+ErrorCode (*gGetHatX)(const AxisEvent*, double*) = nullptr;
+ErrorCode (*gGetHatY)(const AxisEvent*, double*) = nullptr;
+ErrorCode (*gGetBrake)(const AxisEvent*, double*) = nullptr;
+ErrorCode (*gGetGas)(const AxisEvent*, double*) = nullptr;
+ErrorCode (*gGetDeviceChangedType)(const DeviceEvent*, int*) = nullptr;
+ErrorCode (*gGetAllDeviceInfos)(DeviceInfos**) = nullptr;
+ErrorCode (*gGetDeviceCount)(const DeviceInfos*, int32_t*) = nullptr;
+ErrorCode (*gDestroyDeviceInfos)(DeviceInfos**) = nullptr;
+
+struct ButtonData { int code; bool pressed; };
+struct AxisData { int type; double x; double y; };
+struct DeviceData { bool connected; };
+struct RumbleData { uint32_t low; uint32_t high; uint32_t durationMs; };
+
+template<typename T>
+T Resolve(const char* name) {
+    return reinterpret_cast<T>(dlsym(gLibrary, name));
+}
+
+void ButtonJs(napi_env env, napi_value callback, void*, void* raw) {
+    auto* data = static_cast<ButtonData*>(raw);
+    if (env && callback && data) {
+        napi_value values[2], result;
+        napi_create_int32(env, data->code, &values[0]);
+        napi_get_boolean(env, data->pressed, &values[1]);
+        napi_call_function(env, nullptr, callback, 2, values, &result);
+    }
+    delete data;
+}
+
+void AxisJs(napi_env env, napi_value callback, void*, void* raw) {
+    auto* data = static_cast<AxisData*>(raw);
+    if (env && callback && data) {
+        napi_value values[3], result;
+        napi_create_int32(env, data->type, &values[0]);
+        napi_create_double(env, data->x, &values[1]);
+        napi_create_double(env, data->y, &values[2]);
+        napi_call_function(env, nullptr, callback, 3, values, &result);
+    }
+    delete data;
+}
+
+void DeviceJs(napi_env env, napi_value callback, void*, void* raw) {
+    auto* data = static_cast<DeviceData*>(raw);
+    if (env && callback && data) {
+        napi_value value, result;
+        napi_get_boolean(env, data->connected, &value);
+        napi_call_function(env, nullptr, callback, 1, &value, &result);
+    }
+    delete data;
+}
+
+void RumbleJs(napi_env env, napi_value callback, void*, void* raw) {
+    auto* data = static_cast<RumbleData*>(raw);
+    if (env && callback && data) {
+        napi_value values[3], result;
+        napi_create_uint32(env, data->low, &values[0]);
+        napi_create_uint32(env, data->high, &values[1]);
+        napi_create_uint32(env, data->durationMs, &values[2]);
+        napi_call_function(env, nullptr, callback, 3, values, &result);
+    }
+    delete data;
+}
+
+void ForwardRumble(uint16_t low, uint16_t high, uint32_t durationMs) {
+    if (!gRumbleTsfn) return;
+    auto* data = new RumbleData{low, high, durationMs};
+    if (napi_call_threadsafe_function(gRumbleTsfn, data, napi_tsfn_nonblocking) != napi_ok) delete data;
+}
+
+void RefreshDeviceCount() {
+    if (!gGetAllDeviceInfos || !gGetDeviceCount || !gDestroyDeviceInfos) return;
+    DeviceInfos* infos = nullptr;
+    int32_t count = 0;
+    if (gGetAllDeviceInfos(&infos) == 0 && infos) {
+        if (gGetDeviceCount(infos, &count) == 0) {
+            gDeviceCount.store(count, std::memory_order_relaxed);
+        }
+        gDestroyDeviceInfos(&infos);
+    }
+}
+
+void DeviceChanged(const DeviceEvent* event) {
+    if (!event || !gGetDeviceChangedType) return;
+    int type = 0;
+    gGetDeviceChangedType(event, &type);
+    RefreshDeviceCount();
+    const bool connected = (type == 1);
+    winehua::controller::PhysicalFeedDevice(connected);
+    if (!gDeviceTsfn) return;
+    auto* data = new DeviceData{connected};
+    if (napi_call_threadsafe_function(gDeviceTsfn, data, napi_tsfn_nonblocking) != napi_ok) delete data;
+}
+
+void EmitButton(const ButtonEvent* event) {
+    if (!event || !gGetButtonAction || !gGetButtonCode) return;
+    ButtonAction action = 1;
+    int code = 0;
+    gGetButtonAction(event, &action);
+    gGetButtonCode(event, &code);
+    const bool pressed = (action == 0);
+    winehua::controller::PhysicalFeedButton(code, pressed);
+    if (!gButtonTsfn) return;
+    auto* data = new ButtonData{code, pressed};
+    if (napi_call_threadsafe_function(gButtonTsfn, data, napi_tsfn_nonblocking) != napi_ok) delete data;
+}
+
+void ButtonA(const ButtonEvent* event) { EmitButton(event); }
+void ButtonB(const ButtonEvent* event) { EmitButton(event); }
+void ButtonX(const ButtonEvent* event) { EmitButton(event); }
+void ButtonY(const ButtonEvent* event) { EmitButton(event); }
+void ButtonLs(const ButtonEvent* event) { EmitButton(event); }
+void ButtonRs(const ButtonEvent* event) { EmitButton(event); }
+void ButtonLt(const ButtonEvent* event) { EmitButton(event); }
+void ButtonRt(const ButtonEvent* event) { EmitButton(event); }
+void ButtonMenu(const ButtonEvent* event) { EmitButton(event); }
+void ButtonHome(const ButtonEvent* event) { EmitButton(event); }
+void ButtonL3(const ButtonEvent* event) { EmitButton(event); }
+void ButtonR3(const ButtonEvent* event) { EmitButton(event); }
+void ButtonUp(const ButtonEvent* event) { EmitButton(event); }
+void ButtonDown(const ButtonEvent* event) { EmitButton(event); }
+void ButtonLeft(const ButtonEvent* event) { EmitButton(event); }
+void ButtonRight(const ButtonEvent* event) { EmitButton(event); }
+
+void EmitAxis(int type, double x, double y) {
+    winehua::controller::PhysicalFeedAxis(type, x, y);
+    if (!gAxisTsfn) return;
+    auto* data = new AxisData{type, x, y};
+    if (napi_call_threadsafe_function(gAxisTsfn, data, napi_tsfn_nonblocking) != napi_ok) delete data;
+}
+
+void LeftStick(const AxisEvent* event) {
+    double x = 0, y = 0;
+    if (gGetX) gGetX(event, &x);
+    if (gGetY) gGetY(event, &y);
+    EmitAxis(0, x, y);
+}
+
+void RightStick(const AxisEvent* event) {
+    double x = 0, y = 0;
+    if (gGetZ) gGetZ(event, &x);
+    if (gGetRz) gGetRz(event, &y);
+    EmitAxis(1, x, y);
+}
+
+void DpadAxis(const AxisEvent* event) {
+    double x = 0, y = 0;
+    if (gGetHatX) gGetHatX(event, &x);
+    if (gGetHatY) gGetHatY(event, &y);
+    EmitAxis(2, x, y);
+}
+
+void LeftTrigger(const AxisEvent* event) {
+    double value = 0;
+    if (gGetBrake) gGetBrake(event, &value);
+    EmitAxis(3, value, 0);
+}
+
+void RightTrigger(const AxisEvent* event) {
+    double value = 0;
+    if (gGetGas) gGetGas(event, &value);
+    EmitAxis(4, value, 0);
+}
+
+bool RegisterButtonMonitor(const char* registerName, const char* unregisterName, ButtonCallback callback) {
+    const auto registerFunction = Resolve<RegisterButton>(registerName);
+    if (!registerFunction || registerFunction(callback) != 0) return false;
+    const auto unregisterFunction = Resolve<Unregister>(unregisterName);
+    if (unregisterFunction) gUnregisterFunctions.push_back(unregisterFunction);
+    return true;
+}
+
+bool RegisterAxisMonitor(const char* registerName, const char* unregisterName, AxisCallback callback) {
+    const auto registerFunction = Resolve<RegisterAxis>(registerName);
+    if (!registerFunction || registerFunction(callback) != 0) return false;
+    const auto unregisterFunction = Resolve<Unregister>(unregisterName);
+    if (unregisterFunction) gUnregisterFunctions.push_back(unregisterFunction);
+    return true;
+}
+
+int InitializeNative() {
+    std::lock_guard<std::mutex> lock(gMutex);
+    if (gInitialized) return 0;
+    gLibrary = dlopen("libohgame_controller.z.so", RTLD_NOW | RTLD_LOCAL);
+    if (!gLibrary) {
+        OH_LOG_WARN(LOG_APP, "Game Controller Kit unavailable: %{public}s", dlerror());
+        return -1;
+    }
+    gGetButtonAction = Resolve<decltype(gGetButtonAction)>("OH_GamePad_ButtonEvent_GetButtonAction");
+    gGetButtonCode = Resolve<decltype(gGetButtonCode)>("OH_GamePad_ButtonEvent_GetButtonCode");
+    gGetX = Resolve<decltype(gGetX)>("OH_GamePad_AxisEvent_GetXAxisValue");
+    gGetY = Resolve<decltype(gGetY)>("OH_GamePad_AxisEvent_GetYAxisValue");
+    gGetZ = Resolve<decltype(gGetZ)>("OH_GamePad_AxisEvent_GetZAxisValue");
+    gGetRz = Resolve<decltype(gGetRz)>("OH_GamePad_AxisEvent_GetRZAxisValue");
+    gGetHatX = Resolve<decltype(gGetHatX)>("OH_GamePad_AxisEvent_GetHatXAxisValue");
+    gGetHatY = Resolve<decltype(gGetHatY)>("OH_GamePad_AxisEvent_GetHatYAxisValue");
+    gGetBrake = Resolve<decltype(gGetBrake)>("OH_GamePad_AxisEvent_GetBrakeAxisValue");
+    gGetGas = Resolve<decltype(gGetGas)>("OH_GamePad_AxisEvent_GetGasAxisValue");
+    gGetDeviceChangedType = Resolve<decltype(gGetDeviceChangedType)>("OH_GameDevice_DeviceEvent_GetChangedType");
+    gGetAllDeviceInfos = Resolve<decltype(gGetAllDeviceInfos)>("OH_GameDevice_GetAllDeviceInfos");
+    gGetDeviceCount = Resolve<decltype(gGetDeviceCount)>("OH_GameDevice_AllDeviceInfos_GetCount");
+    gDestroyDeviceInfos = Resolve<decltype(gDestroyDeviceInfos)>("OH_GameDevice_DestroyAllDeviceInfos");
+    if (!gGetButtonAction || !gGetButtonCode) {
+        dlclose(gLibrary);
+        gLibrary = nullptr;
+        return -1;
+    }
+
+    RegisterButtonMonitor("OH_GamePad_ButtonA_RegisterButtonInputMonitor", "OH_GamePad_ButtonA_UnregisterButtonInputMonitor", ButtonA);
+    RegisterButtonMonitor("OH_GamePad_ButtonB_RegisterButtonInputMonitor", "OH_GamePad_ButtonB_UnregisterButtonInputMonitor", ButtonB);
+    RegisterButtonMonitor("OH_GamePad_ButtonX_RegisterButtonInputMonitor", "OH_GamePad_ButtonX_UnregisterButtonInputMonitor", ButtonX);
+    RegisterButtonMonitor("OH_GamePad_ButtonY_RegisterButtonInputMonitor", "OH_GamePad_ButtonY_UnregisterButtonInputMonitor", ButtonY);
+    RegisterButtonMonitor("OH_GamePad_LeftShoulder_RegisterButtonInputMonitor", "OH_GamePad_LeftShoulder_UnregisterButtonInputMonitor", ButtonLs);
+    RegisterButtonMonitor("OH_GamePad_RightShoulder_RegisterButtonInputMonitor", "OH_GamePad_RightShoulder_UnregisterButtonInputMonitor", ButtonRs);
+    RegisterButtonMonitor("OH_GamePad_LeftTrigger_RegisterButtonInputMonitor", "OH_GamePad_LeftTrigger_UnregisterButtonInputMonitor", ButtonLt);
+    RegisterButtonMonitor("OH_GamePad_RightTrigger_RegisterButtonInputMonitor", "OH_GamePad_RightTrigger_UnregisterButtonInputMonitor", ButtonRt);
+    RegisterButtonMonitor("OH_GamePad_ButtonMenu_RegisterButtonInputMonitor", "OH_GamePad_ButtonMenu_UnregisterButtonInputMonitor", ButtonMenu);
+    RegisterButtonMonitor("OH_GamePad_ButtonHome_RegisterButtonInputMonitor", "OH_GamePad_ButtonHome_UnregisterButtonInputMonitor", ButtonHome);
+    RegisterButtonMonitor("OH_GamePad_LeftThumbstick_RegisterButtonInputMonitor", "OH_GamePad_LeftThumbstick_UnregisterButtonInputMonitor", ButtonL3);
+    RegisterButtonMonitor("OH_GamePad_RightThumbstick_RegisterButtonInputMonitor", "OH_GamePad_RightThumbstick_UnregisterButtonInputMonitor", ButtonR3);
+    RegisterButtonMonitor("OH_GamePad_Dpad_UpButton_RegisterButtonInputMonitor", "OH_GamePad_Dpad_UpButton_UnregisterButtonInputMonitor", ButtonUp);
+    RegisterButtonMonitor("OH_GamePad_Dpad_DownButton_RegisterButtonInputMonitor", "OH_GamePad_Dpad_DownButton_UnregisterButtonInputMonitor", ButtonDown);
+    RegisterButtonMonitor("OH_GamePad_Dpad_LeftButton_RegisterButtonInputMonitor", "OH_GamePad_Dpad_LeftButton_UnregisterButtonInputMonitor", ButtonLeft);
+    RegisterButtonMonitor("OH_GamePad_Dpad_RightButton_RegisterButtonInputMonitor", "OH_GamePad_Dpad_RightButton_UnregisterButtonInputMonitor", ButtonRight);
+    RegisterAxisMonitor("OH_GamePad_LeftThumbstick_RegisterAxisInputMonitor", "OH_GamePad_LeftThumbstick_UnregisterAxisInputMonitor", LeftStick);
+    RegisterAxisMonitor("OH_GamePad_RightThumbstick_RegisterAxisInputMonitor", "OH_GamePad_RightThumbstick_UnregisterAxisInputMonitor", RightStick);
+    RegisterAxisMonitor("OH_GamePad_Dpad_RegisterAxisInputMonitor", "OH_GamePad_Dpad_UnregisterAxisInputMonitor", DpadAxis);
+    RegisterAxisMonitor("OH_GamePad_LeftTrigger_RegisterAxisInputMonitor", "OH_GamePad_LeftTrigger_UnregisterAxisInputMonitor", LeftTrigger);
+    RegisterAxisMonitor("OH_GamePad_RightTrigger_RegisterAxisInputMonitor", "OH_GamePad_RightTrigger_UnregisterAxisInputMonitor", RightTrigger);
+    const auto registerDevice = Resolve<ErrorCode (*)(DeviceCallback)>("OH_GameDevice_RegisterDeviceMonitor");
+    if (registerDevice && registerDevice(DeviceChanged) == 0) {
+        const auto unregisterDevice = Resolve<Unregister>("OH_GameDevice_UnregisterDeviceMonitor");
+        if (unregisterDevice) gUnregisterFunctions.push_back(unregisterDevice);
+    }
+    RefreshDeviceCount();
+    gInitialized = true;
+    OH_LOG_INFO(LOG_APP, "Game Controller Kit initialized with %{public}zu monitors", gUnregisterFunctions.size());
+    return 0;
+}
+
+void CleanupNative() {
+    std::lock_guard<std::mutex> lock(gMutex);
+    for (auto function : gUnregisterFunctions) function();
+    gUnregisterFunctions.clear();
+    if (gLibrary) dlclose(gLibrary);
+    gLibrary = nullptr;
+    gInitialized = false;
+    gDeviceCount.store(0, std::memory_order_relaxed);
+}
+
+void ReleaseTsfn(napi_threadsafe_function& value) {
+    if (value) napi_release_threadsafe_function(value, napi_tsfn_release);
+    value = nullptr;
+}
+
+bool InstallTsfn(napi_env env, napi_callback_info info, const char* name,
+                 napi_threadsafe_function_call_js callback, napi_threadsafe_function& target) {
+    size_t argc = 1;
+    napi_value args[1] = {};
+    napi_get_cb_info(env, info, &argc, args, nullptr, nullptr);
+    ReleaseTsfn(target);
+    if (argc < 1) return false;
+    napi_valuetype type = napi_undefined;
+    napi_typeof(env, args[0], &type);
+    if (type != napi_function) return false;
+    napi_value resourceName;
+    napi_create_string_utf8(env, name, NAPI_AUTO_LENGTH, &resourceName);
+    return napi_create_threadsafe_function(env, args[0], nullptr, resourceName, 0, 1,
+        nullptr, nullptr, nullptr, callback, &target) == napi_ok;
+}
+
+} // namespace
+
+namespace winehua {
+namespace controller {
+
+int EnsurePhysicalGamepadInitialized()
+{
+    return InitializeNative();
+}
+
+}  // namespace controller
+}  // namespace winehua
+
+napi_value InitGameController(napi_env env, napi_callback_info) {
+    napi_value result;
+    napi_create_int32(env, winehua::controller::EnsurePhysicalGamepadInitialized(), &result);
+    return result;
+}
+
+napi_value CleanupGameController(napi_env, napi_callback_info) {
+    CleanupNative();
+    winehua::controller::GamepadBridge::Instance().SetRumbleListener(nullptr);
+    ReleaseTsfn(gButtonTsfn);
+    ReleaseTsfn(gAxisTsfn);
+    ReleaseTsfn(gDeviceTsfn);
+    ReleaseTsfn(gRumbleTsfn);
+    return nullptr;
+}
+
+napi_value IsGamepadConnected(napi_env env, napi_callback_info) {
+    napi_value result;
+    napi_get_boolean(env, gDeviceCount.load(std::memory_order_relaxed) > 0, &result);
+    return result;
+}
+
+napi_value GetGamepadCount(napi_env env, napi_callback_info) {
+    napi_value result;
+    napi_create_int32(env, gDeviceCount.load(std::memory_order_relaxed), &result);
+    return result;
+}
+
+napi_value SetGamepadButtonCallback(napi_env env, napi_callback_info info) {
+    InstallTsfn(env, info, "WineGamepadButton", ButtonJs, gButtonTsfn);
+    return nullptr;
+}
+
+napi_value SetGamepadAxisCallback(napi_env env, napi_callback_info info) {
+    InstallTsfn(env, info, "WineGamepadAxis", AxisJs, gAxisTsfn);
+    return nullptr;
+}
+
+napi_value SetGamepadDeviceCallback(napi_env env, napi_callback_info info) {
+    InstallTsfn(env, info, "WineGamepadDevice", DeviceJs, gDeviceTsfn);
+    return nullptr;
+}
+
+napi_value SetGamepadRumbleCallback(napi_env env, napi_callback_info info) {
+    InstallTsfn(env, info, "WineGamepadRumble", RumbleJs, gRumbleTsfn);
+    winehua::controller::GamepadBridge::Instance().SetRumbleListener(ForwardRumble);
+    return nullptr;
+}

--- a/entry/src/main/cpp/input/game_controller_bridge.h
+++ b/entry/src/main/cpp/input/game_controller_bridge.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <napi/native_api.h>
+
+namespace winehua {
+namespace controller {
+
+// Starts the dynamically loaded Game Controller Kit monitors. Missing Kit
+// support is a soft failure so Wine can still use touch-fed controller input.
+int EnsurePhysicalGamepadInitialized();
+
+}  // namespace controller
+}  // namespace winehua
+
+napi_value InitGameController(napi_env env, napi_callback_info info);
+napi_value CleanupGameController(napi_env env, napi_callback_info info);
+napi_value IsGamepadConnected(napi_env env, napi_callback_info info);
+napi_value GetGamepadCount(napi_env env, napi_callback_info info);
+napi_value SetGamepadButtonCallback(napi_env env, napi_callback_info info);
+napi_value SetGamepadAxisCallback(napi_env env, napi_callback_info info);
+napi_value SetGamepadDeviceCallback(napi_env env, napi_callback_info info);
+napi_value SetGamepadRumbleCallback(napi_env env, napi_callback_info info);

--- a/entry/src/main/cpp/wine/wine_env.cpp
+++ b/entry/src/main/cpp/wine/wine_env.cpp
@@ -5,6 +5,7 @@
 #include "env_spec.h"
 #include "graphics/graphics_broker.h"
 #include "compositor/wayland_server.h"
+#include "input/controller/controller_runtime.h"
 
 #include <unistd.h>
 #include <algorithm>
@@ -65,6 +66,10 @@ std::vector<std::string> BuildWineEnv(const std::string& sockDir,
             {binDir, homeDir, prefixDir});
         env.insert(env.end(), baseline.begin(), baseline.end());
     }
+    // Start the WHGP socket before spawning Wine and keep its contract near
+    // the front of the NCP environment list.
+    winehua::controller::EnsureBridgeForWineLaunch(prefixDir);
+    winehua::controller::AppendWineGamepadEnv(env);
     // 仅主进程侧基线: locale / WINEDEBUG 静默 / GStreamer 插件路径
     // (子进程 WINEDEBUG 由 select_winedebug_profile 决定, 不走此表)
     env.push_back("WINEDEBUG=-all");

--- a/entry/src/main/cpp/wine/wine_launch.cpp
+++ b/entry/src/main/cpp/wine/wine_launch.cpp
@@ -8,6 +8,7 @@
 #include "compositor/wayland_server.h"
 #include "audio_ipc_protocol.h"
 #include "graphics/graphics_broker.h"
+#include "input/controller/controller_runtime.h"
 
 #include <unistd.h>
 #include <signal.h>
@@ -367,6 +368,10 @@ static bool LaunchPadMode(LaunchParams* p, int audioBootstrapFd, bool* desktopDe
     StartBrokerServer();
     setenv("PROCESSBROKER", WINE_BROKER_SOCKET, 1);
 
+    // winebus loads during wineboot/winedevice startup, so publish the WHGP
+    // socket before the first Wine process is spawned.
+    winehua::controller::EnsureBridgeForWineLaunch(p->prefixDir);
+
     // -- wineserver via broker --
     // broker → wine_child Main → 截获 argv[0]=="wineserver" 转入本体
     // (wineserver 是纯 Unix ELF, 不能走 wine loader 的 PE 解析)。
@@ -456,6 +461,7 @@ static bool LaunchPadMode(LaunchParams* p, int audioBootstrapFd, bool* desktopDe
 #ifdef __aarch64__
         winehua::AppendCompatEnvLines(wbReq.env, p->compatEnvStr);
 #endif
+        winehua::controller::AppendWineGamepadEnv(wbReq.env);
         const pid_t childPid = winehua::Spawner::Spawn(wbReq);
         if (childPid <= 0) {
             OH_LOG_ERROR(LOG_APP, "[Launch-Async] wineboot spawn FAILED");
@@ -527,6 +533,7 @@ static bool LaunchPadMode(LaunchParams* p, int audioBootstrapFd, bool* desktopDe
 #ifdef __aarch64__
         winehua::AppendCompatEnvLines(wbReq.env, p->compatEnvStr);
 #endif
+        winehua::controller::AppendWineGamepadEnv(wbReq.env);
         const pid_t childPid = winehua::Spawner::Spawn(wbReq);
         if (childPid <= 0) {
             OH_LOG_ERROR(LOG_APP, "[Launch-Async] wineboot --init spawn FAILED");

--- a/host_tests/controller_merge_test.cpp
+++ b/host_tests/controller_merge_test.cpp
@@ -1,0 +1,81 @@
+// controller_merge_test.cpp — ControllerHub source ownership (make test)
+#include "input/controller/controller_hub.h"
+#include "input/controller/gamepad_ipc_protocol.h"
+
+#include <cstdio>
+
+using winehua::controller::ButtonBit;
+using winehua::controller::ControllerHub;
+using winehua::controller::ControllerSourceId;
+using winehua::controller::LogicalAxis;
+using winehua::controller::LogicalButton;
+
+static int g_checks = 0;
+static int g_failures = 0;
+
+#define CHECK(cond, msg) do { \
+    ++g_checks; \
+    if (!(cond)) { \
+        ++g_failures; \
+        std::printf("FAIL: %s (%s:%d)\n", msg, __FILE__, __LINE__); \
+    } \
+} while (0)
+
+int main()
+{
+    static_assert(sizeof(whgp_header) == 16, "whgp_header packed size");
+    static_assert(sizeof(whgp_state_v1) == 20, "whgp_state_v1 packed size");
+    static_assert(sizeof(whgp_rumble_v1) == 8, "whgp_rumble_v1 packed size");
+
+    auto& hub = ControllerHub::Instance();
+    hub.SetEnabled(true);
+    hub.SetInnerDeadzone(0.10f);
+
+    // Button ownership: Touch A down, Physical A down, Touch A up → still down
+    hub.SetButton(ControllerSourceId::Touch, 0, LogicalButton::A, true);
+    CHECK(hub.GetState(0).buttons & ButtonBit(LogicalButton::A), "touch A down");
+    hub.SetButton(ControllerSourceId::Physical, 0, LogicalButton::A, true);
+    hub.SetButton(ControllerSourceId::Touch, 0, LogicalButton::A, false);
+    CHECK(hub.GetState(0).buttons & ButtonBit(LogicalButton::A), "physical keeps A");
+    hub.SetButton(ControllerSourceId::Physical, 0, LogicalButton::A, false);
+    CHECK(!(hub.GetState(0).buttons & ButtonBit(LogicalButton::A)), "both released");
+
+    // Trigger max
+    hub.SetAxis(ControllerSourceId::Touch, 0, LogicalAxis::LT, 0.4f);
+    hub.SetAxis(ControllerSourceId::Physical, 0, LogicalAxis::LT, 0.8f);
+    CHECK(hub.GetState(0).lt > 20000, "trigger max physical");
+    hub.SetAxis(ControllerSourceId::Physical, 0, LogicalAxis::LT, 0.f);
+    CHECK(hub.GetState(0).lt > 10000, "trigger remains touch");
+
+    // ResetSource clears only that source
+    hub.SetButton(ControllerSourceId::Touch, 0, LogicalButton::B, true);
+    hub.SetButton(ControllerSourceId::Physical, 0, LogicalButton::B, true);
+    hub.ResetSource(ControllerSourceId::Touch);
+    CHECK(hub.GetState(0).buttons & ButtonBit(LogicalButton::B), "physical B after touch reset");
+    hub.ResetSource(ControllerSourceId::Physical);
+    CHECK(!(hub.GetState(0).buttons & ButtonBit(LogicalButton::B)), "all clear");
+
+    // Stick deadzone
+    hub.SetAxis(ControllerSourceId::Physical, 0, LogicalAxis::LX, 0.05f);
+    hub.SetAxis(ControllerSourceId::Physical, 0, LogicalAxis::LY, 0.05f);
+    CHECK(hub.GetState(0).lx == 0 && hub.GetState(0).ly == 0, "inside deadzone");
+    hub.SetAxis(ControllerSourceId::Physical, 0, LogicalAxis::LX, 1.0f);
+    hub.SetAxis(ControllerSourceId::Physical, 0, LogicalAxis::LY, 0.0f);
+    CHECK(hub.GetState(0).lx > 20000, "full stick X");
+
+    // Last-active stick: Touch after Physical takes ownership; Touch release falls back.
+    hub.SetAxis(ControllerSourceId::Physical, 0, LogicalAxis::LX, 1.0f);
+    hub.SetAxis(ControllerSourceId::Physical, 0, LogicalAxis::LY, 0.0f);
+    hub.SetAxis(ControllerSourceId::Touch, 0, LogicalAxis::LX, 0.5f);
+    hub.SetAxis(ControllerSourceId::Touch, 0, LogicalAxis::LY, 0.0f);
+    CHECK(hub.GetState(0).lx > 10000 && hub.GetState(0).lx < 20000, "touch last-active");
+    hub.SetAxis(ControllerSourceId::Touch, 0, LogicalAxis::LX, 0.0f);
+    hub.SetAxis(ControllerSourceId::Touch, 0, LogicalAxis::LY, 0.0f);
+    CHECK(hub.GetState(0).lx > 20000, "physical fallback after touch");
+    hub.ResetSource(ControllerSourceId::Physical);
+    hub.ResetSource(ControllerSourceId::Touch);
+
+    hub.SetEnabled(false);
+    std::printf("controller_merge_test: %d checks, %d failures\n", g_checks, g_failures);
+    return g_failures ? 1 : 0;
+}


### PR DESCRIPTION
## Why

The product branch has a complete native Controller Hub path, while master does not yet expose the corresponding host/Wine C interface. Porting the native architecture now keeps future controller work aligned with the refactored master without changing the product UI.

## Changes

- add the native Controller Hub core, physical gamepad bridge, and fixed wire protocol
- expose the controller N-API surface in the refactored native bridge
- start the physical gamepad bridge idempotently from native launch code
- create and export the WHGP socket before wineboot and wineserver startup
- pass the same socket environment through both wineboot paths
- advance the Wine gitlink to the matching winehua/wine#4 implementation

The C wire ABI remains fixed at a 16-byte header, 20-byte state payload, and 8-byte rumble payload. ArkTS UI, settings pages, language resources, and SmokeRunner are excluded.

## Validation

- Controller Hub host protocol test: 11/11 checks passed
- all 9 affected HarmonyOS ARM64 native translation units compiled with the OHOS SDK toolchain
- Wine OHOS Unix `winebus.so`, i386 `winebus.sys`, and x86_64 `winebus.sys` targets built successfully

## Dependency

- winehua/wine#4 should merge before this root gitlink is merged
